### PR TITLE
MarkerObject: name should be text, not bytes

### DIFF
--- a/qcore/decorators.py
+++ b/qcore/decorators.py
@@ -28,6 +28,7 @@ __all__ = [
     'decorator_of_context_manager',
 ]
 
+import cython
 import functools
 import inspect
 from six.moves import xrange
@@ -63,21 +64,33 @@ class DecoratorBinder(object):
     def __repr__(self):
         return self.__str__()
 
-    def __cmp__(self, other):
-        """Compare objects for equality (so we can run tests that do an equality check).
-
-        This is implemented using __cmp__ because this is the only way that works in both
-        Cythonized and non-Cythonized classes.
-
-        """
-        if self.__class__ is other.__class__ and self.decorator == other.decorator and \
-                self.instance == other.instance:
-            return 0
-        else:
-            return -1
+    # This awkward implementation is necessary so that binders can be compared for equality across
+    # Cythonized and non-Cythonized Python 2 and 3. In pure-Python compiled classes, Cython only
+    # supports overriding __richcmp__, not __eq__ (https://github.com/cython/cython/issues/690),
+    # but if __eq__ is defined it throws an error.
+    if cython.compiled:
+        def __richcmp__(self, other, op):
+            """Compare objects for equality (so we can run tests that do an equality check)."""
+            if op in (2, 3): # ==, !=
+                if self.__class__ is other.__class__ and self.decorator == other.decorator and \
+                        self.instance == other.instance:
+                    equal = True
+                else:
+                    equal = False
+                return equal if op == 2 else not equal
+            else:
+                return NotImplemented
 
     def __hash__(self):
         return hash(self.decorator) ^ hash(self.instance)
+
+
+if not cython.compiled:
+    def __eq__(self, other):
+        return self.__class__ is other.__class__ and self.decorator == other.decorator and \
+            self.instance == other.instance
+    DecoratorBinder.__eq__ = __eq__
+    del __eq__
 
 
 class DecoratorBase(object):

--- a/qcore/helpers.pxd
+++ b/qcore/helpers.pxd
@@ -22,7 +22,7 @@ cdef dict empty_dict
 
 
 cdef class MarkerObject(object):
-    cpdef str name
+    cpdef unicode name
 
 cdef MarkerObject none
 cdef MarkerObject miss

--- a/qcore/helpers.py
+++ b/qcore/helpers.py
@@ -52,8 +52,15 @@ class MarkerObject(object):
             name = name.decode('utf-8')
         self.name = name
 
-    def __str__(self):
-        return self.name
+    if six.PY2:
+        def __str__(self):
+            return unicode(self).encode('utf-8')
+
+        def __unicode__(self):
+            return self.name
+    else:
+        def __str__(self):
+            return self.name
 
     def __repr__(self):
         return self.name

--- a/qcore/helpers.py
+++ b/qcore/helpers.py
@@ -19,6 +19,8 @@ Various small helper classes and routines.
 """
 
 import inspect
+import six
+import warnings
 
 from . import inspectable_class
 
@@ -45,6 +47,9 @@ class MarkerObject(object):
 
     """
     def __init__(self, name):
+        if six.PY2 and isinstance(name, six.binary_type):
+            warnings.warnpy3k('MarkerObject does not support bytes names in Python 3')
+            name = name.decode('utf-8')
         self.name = name
 
     def __str__(self):
@@ -53,10 +58,10 @@ class MarkerObject(object):
     def __repr__(self):
         return self.name
 
-none = MarkerObject('none')
-miss = MarkerObject('miss')
-same = MarkerObject('same')
-unspecified = MarkerObject('unspecified')
+none = MarkerObject(u'none')
+miss = MarkerObject(u'miss')
+same = MarkerObject(u'same')
+unspecified = MarkerObject(u'unspecified')
 globals()['none'] = none
 globals()['miss'] = miss
 globals()['same'] = same

--- a/qcore/tests/test_helpers.py
+++ b/qcore/tests/test_helpers.py
@@ -15,9 +15,10 @@
 from __future__ import print_function
 import qcore
 from qcore.asserts import (
-    assert_eq, assert_is, assert_ne, assert_gt, assert_is_not,
+    assert_eq, assert_is, assert_ne, assert_is_not,
     assert_is_substring, AssertRaises
 )
+import six
 
 v = qcore.ScopedValue('a')
 
@@ -250,3 +251,17 @@ def test_safe_representation():
     assert_eq('\'a\'', qcore.safe_repr('a'))
     assert_eq('\'...', qcore.safe_repr('2.192842', max_length=4))
     assert_eq('<n/a: repr...', qcore.safe_repr(TestObject(), max_length=13))
+
+
+def test_marker_object():
+    assert_eq('text', six.text_type(qcore.MarkerObject('text')))
+
+    # bytes should work in py2 but not py3
+    if six.PY2:
+        assert_eq(b'bytes', six.text_type(qcore.MarkerObject(b'bytes')))
+    else:
+        with AssertRaises(TypeError):
+            qcore.MarkerObject(b'bytes')
+
+    # MarkerObjects should be unique
+    assert_ne(qcore.MarkerObject('name'), qcore.MarkerObject('name'))

--- a/qcore/tests/test_helpers.py
+++ b/qcore/tests/test_helpers.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import qcore
 from qcore.asserts import (
     assert_eq, assert_is, assert_ne, assert_is_not,
-    assert_is_substring, AssertRaises
+    assert_is_substring, AssertRaises, assert_is_instance
 )
 import six
 
@@ -255,10 +255,12 @@ def test_safe_representation():
 
 def test_marker_object():
     assert_eq('text', six.text_type(qcore.MarkerObject('text')))
+    assert_is_instance(six.text_type(qcore.MarkerObject('text')), six.text_type)
 
     # bytes should work in py2 but not py3
     if six.PY2:
-        assert_eq(b'bytes', six.text_type(qcore.MarkerObject(b'bytes')))
+        assert_eq(u'bytes', six.text_type(qcore.MarkerObject(b'bytes')))
+        assert_eq(b'bytes', six.binary_type(qcore.MarkerObject(b'bytes')))
     else:
         with AssertRaises(TypeError):
             qcore.MarkerObject(b'bytes')


### PR DESCRIPTION
Ran into this while migrating some code using MarkerObjects to Python 3. The
name of the MarkerObject is supposed to be a human-readable label, so it
should be text, not bytes.

This change enforces that the name is str (i.e., text) in Python 3. In Python 2,
we allow both but issue a warning when using str (i.e., bytes in Python 3).

Passes tests in Python 2.7 and 3.5 on OS X.