### PR TITLE
Fix test_caching.py test failures under Python 3

### DIFF
--- a/qcore/tests/test_caching.py
+++ b/qcore/tests/test_caching.py
@@ -186,7 +186,7 @@ class TestLRUCache(object):
 
         assert_eq(keys, list(cache))
 
-        assert_eq(keys, cache.keys())
+        assert_eq(keys, list(cache.keys()))
 
         assert_eq(values, list(cache.values()))
 


### PR DESCRIPTION
.keys() returns a special view, not a list, in Python 3.

There is an additional test failure in test_decorators.py that I'm not
sure yet how to fix; it's not obvious how to create an equality check
that works across Cythonized and non-Cythonized Python 2 and 3.