### PR TITLE
qcore: fix DecoratorBinder equality

### DIFF
--- a/qcore/decorators.py
+++ b/qcore/decorators.py
@@ -28,6 +28,7 @@ __all__ = [
     'decorator_of_context_manager',
 ]
 
+import cython
 import functools
 import inspect
 from six.moves import xrange
@@ -63,21 +64,33 @@ class DecoratorBinder(object):
     def __repr__(self):
         return self.__str__()
 
-    def __cmp__(self, other):
-        """Compare objects for equality (so we can run tests that do an equality check).
-
-        This is implemented using __cmp__ because this is the only way that works in both
-        Cythonized and non-Cythonized classes.
-
-        """
-        if self.__class__ is other.__class__ and self.decorator == other.decorator and \
-                self.instance == other.instance:
-            return 0
-        else:
-            return -1
+    # This awkward implementation is necessary so that binders can be compared for equality across
+    # Cythonized and non-Cythonized Python 2 and 3. In pure-Python compiled classes, Cython only
+    # supports overriding __richcmp__, not __eq__ (https://github.com/cython/cython/issues/690),
+    # but if __eq__ is defined it throws an error.
+    if cython.compiled:
+        def __richcmp__(self, other, op):
+            """Compare objects for equality (so we can run tests that do an equality check)."""
+            if op in (2, 3): # ==, !=
+                if self.__class__ is other.__class__ and self.decorator == other.decorator and \
+                        self.instance == other.instance:
+                    equal = True
+                else:
+                    equal = False
+                return equal if op == 2 else not equal
+            else:
+                return NotImplemented
 
     def __hash__(self):
         return hash(self.decorator) ^ hash(self.instance)
+
+
+if not cython.compiled:
+    def __eq__(self, other):
+        return self.__class__ is other.__class__ and self.decorator == other.decorator and \
+            self.instance == other.instance
+    DecoratorBinder.__eq__ = __eq__
+    del __eq__
 
 
 class DecoratorBase(object):


### PR DESCRIPTION
This code (hacky though it is) works in Python 2 and 3, with and without
Cython. All tests pass in Python 3 now.