### PR TITLE
optimize memoize

### DIFF
--- a/qcore/caching.py
+++ b/qcore/caching.py
@@ -320,10 +320,12 @@ def memoize(fun):
     is called on the function.
 
     """
+    argspec = inspect.getargspec(fun)
+    arg_names = argspec.args[1:]  # remove self
+    kwargs_defaults = get_kwargs_defaults(argspec)
 
     def cache_key(args, kwargs):
-        locals_dict = inspect.getcallargs(fun, *args, **kwargs)
-        return tuple(sorted(locals_dict.items()))
+        return get_args_tuple(args, kwargs, arg_names, kwargs_defaults)
 
     @functools.wraps(fun)
     def new_fun(*args, **kwargs):
@@ -356,6 +358,13 @@ def memoize_with_ttl(ttl_secs=60 * 60 * 24):
     assert_gt(ttl_secs, 0, error_msg)
 
     def cache_fun(fun):
+        argspec = inspect.getargspec(fun)
+        arg_names = argspec.args[1:]  # remove self
+        kwargs_defaults = get_kwargs_defaults(argspec)
+
+        def cache_key(args, kwargs):
+            return get_args_tuple(args, kwargs, arg_names, kwargs_defaults)
+
         def cache_key(args, kwargs):
             locals_dict = inspect.getcallargs(fun, *args, **kwargs)
             return repr(sorted(locals_dict.items()))

--- a/qcore/caching.py
+++ b/qcore/caching.py
@@ -363,11 +363,7 @@ def memoize_with_ttl(ttl_secs=60 * 60 * 24):
         kwargs_defaults = get_kwargs_defaults(argspec)
 
         def cache_key(args, kwargs):
-            return get_args_tuple(args, kwargs, arg_names, kwargs_defaults)
-
-        def cache_key(args, kwargs):
-            locals_dict = inspect.getcallargs(fun, *args, **kwargs)
-            return repr(sorted(locals_dict.items()))
+            return repr(get_args_tuple(args, kwargs, arg_names, kwargs_defaults))
 
         @functools.wraps(fun)
         def new_fun(*args, **kwargs):

--- a/qcore/caching.py
+++ b/qcore/caching.py
@@ -321,7 +321,7 @@ def memoize(fun):
 
     """
     argspec = inspect.getargspec(fun)
-    arg_names = argspec.args[1:]  # remove self
+    arg_names = argspec.args
     kwargs_defaults = get_kwargs_defaults(argspec)
 
     def cache_key(args, kwargs):
@@ -359,7 +359,7 @@ def memoize_with_ttl(ttl_secs=60 * 60 * 24):
 
     def cache_fun(fun):
         argspec = inspect.getargspec(fun)
-        arg_names = argspec.args[1:]  # remove self
+        arg_names = argspec.args
         kwargs_defaults = get_kwargs_defaults(argspec)
 
         def cache_key(args, kwargs):


### PR DESCRIPTION
As @ymichael noticed, @memoize is inefficient because it ends up calling inspect.getargspec every time the memoized function is called. This patch uses get_args_tuple instead, which should be more efficient.