### PR TITLE
qcore: fix pure-python import

### DIFF
--- a/qcore/caching.py
+++ b/qcore/caching.py
@@ -43,7 +43,7 @@ from . import helpers
 
 
 miss = helpers.miss
-not_computed = helpers.MarkerObject('not_computed @ qcore.caching')
+not_computed = helpers.MarkerObject(u'not_computed @ qcore.caching')
 globals()['miss'] = miss
 globals()['not_computed'] = not_computed
 

--- a/qcore/decorators.py
+++ b/qcore/decorators.py
@@ -28,7 +28,13 @@ __all__ = [
     'decorator_of_context_manager',
 ]
 
-import cython
+# make sure qcore is still importable if this module has not been compiled with Cython and Cython
+# is not installed
+try:
+    from cython import compiled
+except ImportError:
+    compiled = False
+
 import functools
 import inspect
 from six.moves import xrange
@@ -68,7 +74,7 @@ class DecoratorBinder(object):
     # Cythonized and non-Cythonized Python 2 and 3. In pure-Python compiled classes, Cython only
     # supports overriding __richcmp__, not __eq__ (https://github.com/cython/cython/issues/690),
     # but if __eq__ is defined it throws an error.
-    if cython.compiled:
+    if compiled:
         def __richcmp__(self, other, op):
             """Compare objects for equality (so we can run tests that do an equality check)."""
             if op in (2, 3): # ==, !=
@@ -85,7 +91,7 @@ class DecoratorBinder(object):
         return hash(self.decorator) ^ hash(self.instance)
 
 
-if not cython.compiled:
+if not compiled:
     def __eq__(self, other):
         return self.__class__ is other.__class__ and self.decorator == other.decorator and \
             self.instance == other.instance

--- a/qcore/enum.py
+++ b/qcore/enum.py
@@ -26,7 +26,7 @@ import six
 from . import helpers
 from . import inspection
 
-_no_default = helpers.MarkerObject('no_default @ enums')
+_no_default = helpers.MarkerObject(u'no_default @ enums')
 
 
 class EnumType(type):


### PR DESCRIPTION
Otherwise, cython is a run-time dependency when
qcore is run as pure Python.

Also fix MarkerObjects to use unicode names in
Python 2, because using str now produces a
warning.