### PR TITLE
enum: various changes

### DIFF
--- a/qcore/enum.py
+++ b/qcore/enum.py
@@ -239,7 +239,7 @@ class Enum(EnumBase):
         """
         if isinstance(value, cls):
             return value
-        elif isinstance(value, six.integer_types):
+        elif isinstance(value, six.integer_types) and not isinstance(value, EnumBase):
             e = cls._value_to_member.get(value, _no_default)
         else:
             e = cls._name_to_member.get(value, _no_default)

--- a/qcore/enum.py
+++ b/qcore/enum.py
@@ -200,6 +200,7 @@ class EnumBase(six.with_metaclass(EnumType)):
 
     @classmethod
     def parse(cls, value, default=_no_default):
+        """Parses a value into a member of this enum."""
         raise NotImplementedError
 
 
@@ -214,6 +215,28 @@ class Enum(EnumBase):
 
     @classmethod
     def parse(cls, value, default=_no_default):
+        """Parses an enum member name or value into an enum member.
+
+        Accepts the following types:
+        - Members of this enum class. These are returned directly.
+        - Integers. If there is an enum member with the integer as a value, that member is returned.
+        - Strings. If there is an enum member with the string as its name, that member is returned.
+        For integers and strings that don't correspond to an enum member, default is returned; if
+        no default is given the function raises KeyError instead.
+
+        Examples:
+
+        >>> class Color(Enum):
+        ...     red = 1
+        ...     blue = 2
+        >>> Color.parse(Color.red)
+        Color.red
+        >>> Color.parse(1)
+        Color.red
+        >>> Color.parse('blue')
+        Color.blue
+
+        """
         if isinstance(value, cls):
             return value
         elif isinstance(value, six.integer_types):
@@ -253,6 +276,27 @@ class Flags(EnumBase):
 
     @classmethod
     def parse(cls, value, default=_no_default):
+        """Parses a flag integer or string into a Flags instance.
+
+        Accepts the following types:
+        - Members of this enum class. These are returned directly.
+        - Integers. These are converted directly into a Flags instance with the given name.
+        - Strings. The function accepts a comma-delimited list of flag names, corresponding to
+          members of the enum. These are all ORed together.
+
+        Examples:
+
+        >>> class Car(Flags):
+        ...     is_big = 1
+        ...     has_wheels = 2
+        >>> Car.parse(1)
+        Car.is_big
+        >>> Car.parse(3)
+        Car.parse('has_wheels,is_big')
+        >>> Car.parse('is_big,has_wheels')
+        Car.parse('has_wheels,is_big')
+
+        """
         if isinstance(value, cls):
             return value
         elif isinstance(value, int):

--- a/qcore/tests/test_enum.py
+++ b/qcore/tests/test_enum.py
@@ -16,7 +16,7 @@ import json
 from qcore.enum import Enum, Flags, IntEnum, EnumValueGenerator
 from qcore.asserts import (
     assert_eq, assert_is, assert_ne, assert_raises, assert_in, assert_not_in,
-    assert_is_instance, assert_unordered_list_eq
+    assert_is_instance
 )
 
 
@@ -42,8 +42,8 @@ def _assert_equality_both_directions(left, right, not_equal):
 
 def test_gender():
     assert_eq([2, 1], Gender._flag_values)
-    assert_eq(3, len(Gender.get_members()))
-    assert_unordered_list_eq(['female', 'male', 'undefined'], Gender.get_names())
+    assert_eq([Gender.undefined, Gender.male, Gender.female], Gender.get_members())
+    assert_eq(['undefined', 'male', 'female'], Gender.get_names())
     assert_eq(3, len(Gender))
 
     _assert_equality_both_directions(0, Gender.undefined, 1)
@@ -79,11 +79,13 @@ def test_gender():
     assert_is(None, Gender.parse(4, None))
     assert_raises(lambda: Gender.parse(''), KeyError)
     assert_raises(lambda: Gender.parse(4), KeyError)
+    assert_is(None, Gender('', None))
+    assert_is(None, Gender(4, None))
+    assert_raises(lambda: Gender(''), KeyError)
+    assert_raises(lambda: Gender(4), KeyError)
 
     assert_eq(str(Gender.male), 'male')
     assert_eq(repr(Gender.male), 'Gender.male')
-    assert_eq(str(Gender(5)), 'Gender(5)')
-    assert_eq(repr(Gender(5)), 'Gender(5)')
 
 
 def test_property():
@@ -94,13 +96,20 @@ def test_property():
 
 def test_create():
     def test_exact_gender(cls):
-        assert_eq(len(cls.get_members()), 2)
-        assert_unordered_list_eq(list(cls), [cls.male, cls.female])
-        assert_eq(cls.male, 1)
-        assert_eq(cls.female, 2)
+        assert_eq([cls.male, cls.female], cls.get_members())
+        assert_eq([cls.male, cls.female], list(cls))
+        assert_eq(1, cls.male)
+        assert_eq(2, cls.female)
         assert_eq(cls.male, Gender.male)
         assert_eq(cls.female, Gender.female)
         assert_in(cls.male, cls)
+
+        assert_eq(cls.male, cls.parse(1))
+        assert_eq(cls.male, cls.parse('male'))
+        assert_eq(cls.male, cls.parse(cls.male))
+        assert_eq(cls.male, cls(1))
+        assert_eq(cls.male, cls('male'))
+        assert_eq(cls.male, cls(cls.male))
 
     class ExactGender(Enum):
         male = Gender.male
@@ -142,25 +151,40 @@ class Xyzna(Xyz):
 
 def test_xyz():
     assert_eq([8, 5, 4, 1], Xyz._flag_values)
-    assert_eq(3, len(Xy.get_members()))
-    assert_eq(4, len(Xyz.get_members()))
-    assert_eq(5, len(Xyzna.get_members()))
-    assert_eq('[Xyzna.na, Xyzna.x, Xyzna.xy, Xyzna.y, Xyzna.z]',
+    assert_eq([Xy.x, Xy.y, Xy.xy], Xy.get_members())
+    assert_eq([Xyz.x, Xyz.y, Xyz.xy, Xyz.z], Xyz.get_members())
+    assert_eq([Xyzna.na, Xyzna.x, Xyzna.y, Xyzna.xy, Xyzna.z], Xyzna.get_members())
+    assert_eq('[Xyzna.na, Xyzna.x, Xyzna.y, Xyzna.xy, Xyzna.z]',
               str(Xyzna.get_members()))
 
     assert_eq(0, Xyz.parse(''))
     assert_eq(0, Xyz.parse(0))
     assert_eq(0, Xyzna.parse('na'))
     assert_is(None, Xyz.parse('na', None))
+    assert_eq(0, Xyz(''))
+    assert_eq(0, Xyz(0))
+    assert_eq(0, Xyzna('na'))
+    assert_is(None, Xyz('na', None))
 
     assert_raises(lambda: Xyz.parse('_'), KeyError)
     assert_raises(lambda: Xyz.parse('x,_'), KeyError)
+    assert_raises(lambda: Xyz('_'), KeyError)
+    assert_raises(lambda: Xyz('x,_'), KeyError)
 
     assert_eq(4, Xyz.parse('y'))
     assert_eq(4, Xyz.parse(4))
+    assert_eq(4, Xyz('y'))
+    assert_eq(4, Xyz(4))
 
     assert_eq(5, Xyz.parse('xy'))
     assert_eq(5, Xyz.parse('x,y'))
+    assert_eq(5, Xyz('xy'))
+    assert_eq(5, Xyz('x,y'))
+
+    assert_is(None, Xyz.parse(100, None))
+    assert_raises(lambda: Xyz.parse(100), KeyError)
+    assert_is(None, Xyz(100, None))
+    assert_raises(lambda: Xyz(100), KeyError)
 
     assert_eq('x', Xyz(1).short_name)
     assert_eq('y', Xyz(4).short_name)
@@ -169,17 +193,12 @@ def test_xyz():
     assert_eq('', Xyz(0).short_name)
     assert_eq('na', Xyzna(0).short_name)
 
-    assert_is(None, Xyz.parse(100, None))
-    assert_raises(lambda: Xyz.parse(100), KeyError)
-
     assert_eq('z', str(Xyz.z))
     assert_eq('Xyz.z', repr(Xyz.z))
     assert_eq('xy', str(Xyz.xy))
     assert_eq('Xyz.xy', repr(Xyz.xy))
     assert_eq('z,x', str(Xyz.x | Xyz.z))
     assert_eq("Xyz.parse('z,x')", repr(Xyz.x | Xyz.z))
-    assert_eq('Xyz(100)', str(Xyz(100)))
-    assert_eq('Xyz(100)', repr(Xyz(100)))
 
 
 def test_instances():
@@ -198,10 +217,8 @@ def test_instances():
     assert_eq(Gender(0), Gender.undefined)
     assert_eq(Gender(1), Gender.male)
     assert_eq(Gender(2), Gender.female)
-    assert_ne(Gender(3), Gender.female)
 
     assert Gender(0).is_valid()
-    assert not Gender(3).is_valid()
 
     g0 = Gender.parse(0)
     assert isinstance(g0, Gender)
@@ -215,8 +232,6 @@ def test_instances():
 
     assert_eq('xy', str(Xyz.xy))
     assert_eq('Xyz.xy', repr(Xyz.xy))
-    assert_eq('Xyz(1000)', str(Xyz(1000)))
-    assert_eq('Xyz(1000)', repr(Xyz(1000)))
 
     assert_eq(Xyz.xy, Xyz.x | Xyz.y)
     assert_eq(5, Xyz.x | Xyz.y)
@@ -305,3 +320,18 @@ def test_bad_enum():
             member2 = 1
 
     assert_raises(declare_bad_enum, AssertionError)
+
+
+try:
+    _long_type = long
+except NameError:
+    _long_type = int
+
+
+class LongEnum(Enum):
+    x = _long_type(100)
+
+
+def test_long_enum():
+    assert_is_instance(LongEnum.x, LongEnum)
+    assert_is_instance(LongEnum.x.value, _long_type)

--- a/qcore/tests/test_enum.py
+++ b/qcore/tests/test_enum.py
@@ -33,6 +33,12 @@ class Gender(Enum):
         return Gender(3 - self.value)
 
 
+class SeparateEnum(IntEnum):
+    undefined = 0
+    male = 1
+    female = 2
+
+
 def _assert_equality_both_directions(left, right, not_equal):
     assert_eq(left, right)
     assert_eq(right, left)
@@ -66,6 +72,7 @@ def test_gender():
 
     assert_is(None, Gender.parse('na', None))
     assert_raises(lambda: Gender.parse('na'), KeyError)
+    assert_raises(lambda: Gender.parse(SeparateEnum.undefined), KeyError)
 
     assert_eq('undefined', Gender(0).short_name)
     assert_eq('male', Gender(1).short_name)

--- a/qcore/tests/test_enum.py
+++ b/qcore/tests/test_enum.py
@@ -334,4 +334,3 @@ class LongEnum(Enum):
 
 def test_long_enum():
     assert_is_instance(LongEnum.x, LongEnum)
-    assert_is_instance(LongEnum.x.value, _long_type)


### PR DESCRIPTION
- Allow longs as enum values in Python 2.
- Ensure members are returned in order of their values in
  get_names() and get_members().
- Make enum values singletons instead of creating new ones
  in e.g. .parse().
- Make instantiating an enum equivalent to calling .parse()
  on it.
- As a consequence, disallow instantiating an enum with an
  invalid value.

The last few changes were more invasive than I'd hoped, and
required a few behavior changes in the tests. I don't think
this will affect real use cases.