### PR TITLE
qcore: make DisallowInheritance work with six.with_metaclass

### DIFF
--- a/qcore/disallow_inheritance.py
+++ b/qcore/disallow_inheritance.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import inspection
-from .inspection import get_original_fn, get_full_name
-from .errors import *
-from .helpers import *
-from .enum import *
-from .microtime import *
-from . import events
-from .events import EventHook, EventHub, EnumBasedEventHub, \
-    EventInterceptor, sinking_event_hook
-from .decorators import *
-from .caching import *
-from . import debug
-from . import testing
-from . import asserts
-from .inspectable_class import InspectableClass
-from .disallow_inheritance import DisallowInheritance
+__doc__ = """
+
+Provides a metaclass that prevents inheritance from its instances.
+
+"""
+
+
+class DisallowInheritance(type):
+    """Metaclass that disallows inheritance from classes using it."""
+    def __init__(self, cl_name, bases, namespace):
+        for cls in bases:
+            if isinstance(cls, DisallowInheritance):
+                message = 'Class %s cannot be used as a base for newly defined class %s' % \
+                    (cls, cl_name)
+                raise TypeError(message)
+        super(DisallowInheritance, self).__init__(cl_name, bases, namespace)

--- a/qcore/helpers.py
+++ b/qcore/helpers.py
@@ -24,6 +24,9 @@ import warnings
 
 from . import inspectable_class
 
+# export it here for backward compatibility
+from .disallow_inheritance import DisallowInheritance
+
 
 empty_tuple = ()
 empty_list = []
@@ -272,17 +275,6 @@ def object_from_string(st):
     func_name = st[pos + 1:]
     mod = __import__(module_name, fromlist=[func_name], level=0)
     return getattr(mod, func_name)
-
-
-class DisallowInheritance(type):
-    """Metaclass that disallows inheritance from classes using it."""
-    def __init__(self, cl_name, bases, namespace):
-        for cls in bases:
-            if isinstance(cls, DisallowInheritance):
-                message = 'Class %s cannot be used as a base for newly defined class %s' % \
-                    (cls, cl_name)
-                raise TypeError(message)
-        super(DisallowInheritance, self).__init__(cl_name, bases, namespace)
 
 
 def catchable_exceptions(exceptions):

--- a/qcore/tests/test_disallow_inheritance.py
+++ b/qcore/tests/test_disallow_inheritance.py
@@ -1,0 +1,13 @@
+import qcore
+from qcore.asserts import AssertRaises
+import six
+
+
+class Foo(six.with_metaclass(qcore.DisallowInheritance)):
+    pass
+
+
+def test_disallow_inheritance():
+    with AssertRaises(TypeError):
+        class Bar(Foo):
+            pass

--- a/qcore/tests/test_helpers.py
+++ b/qcore/tests/test_helpers.py
@@ -185,21 +185,6 @@ def test_cached_hash_wrapper():
     assert_ne(hash(w1b), hash(w2a))
 
 
-# using six.with_metaclass doesn't work here on Python 2, maybe because DisallowInheritance is
-# cythonized
-try:
-    exec("class Foo(metaclass=qcore.helpers.DisallowInheritance): pass")
-except SyntaxError:
-    class Foo(object):
-        __metaclass__ = qcore.helpers.DisallowInheritance
-
-
-def test_disallow_inheritance():
-    with AssertRaises(TypeError):
-        class Bar(Foo):
-            pass
-
-
 def _stub_serializable_func():
     pass
 


### PR DESCRIPTION
Seems to be some bad interaction with Cython.