### PR TITLE
enums: fix KeyError with unicode value in Python 2

### DIFF
--- a/qcore/enum.py
+++ b/qcore/enum.py
@@ -384,4 +384,4 @@ class EnumValueGenerator(object):
 
 def _create_invalid_value_error(cls, value):
     return KeyError(
-        "Invalid %s value: %s" % (inspection.get_full_name(cls), value))
+        "Invalid %s value: %r" % (inspection.get_full_name(cls), value))

--- a/qcore/tests/test_enum.py
+++ b/qcore/tests/test_enum.py
@@ -74,6 +74,10 @@ def test_gender():
     assert_is(None, Gender.parse('na', None))
     assert_raises(lambda: Gender.parse('na'), KeyError)
     assert_raises(lambda: Gender.parse(SeparateEnum.undefined), KeyError)
+    assert_raises(lambda: Gender.parse(b'ni\xc3\xb1o'), KeyError)
+    assert_raises(lambda: Gender.parse(u'ni\xf1o'), KeyError)
+    assert_raises(lambda: Gender.parse(b'ni\xff\xffo'), KeyError)
+    assert_raises(lambda: Gender.parse(u'\xe4\xb8\xad\xe6\x96\x87'), KeyError)
 
     assert_eq('undefined', Gender(0).short_name)
     assert_eq('male', Gender(1).short_name)


### PR DESCRIPTION
Some of the new tests fail in Python 2 (but not Python 3) without this change.