### PR TITLE
getargspec: improved handling of Python 3 functions

### DIFF
--- a/qcore/caching.py
+++ b/qcore/caching.py
@@ -33,13 +33,13 @@ __all__ = [
 from collections import OrderedDict
 import threading
 import functools
-import inspect
 import six
 import time
 import types
 
 from .asserts import assert_is_instance, assert_gt
 from . import helpers
+from . import inspection
 
 
 miss = helpers.miss
@@ -241,7 +241,7 @@ def cached_per_instance():
 
     """
     def cache_fun(fun):
-        argspec = inspect.getargspec(fun)
+        argspec = inspection.getargspec(fun)
         arg_names = argspec.args[1:]  # remove self
         kwargs_defaults = get_kwargs_defaults(argspec)
 
@@ -320,7 +320,7 @@ def memoize(fun):
     is called on the function.
 
     """
-    argspec = inspect.getargspec(fun)
+    argspec = inspection.getargspec(fun)
     arg_names = argspec.args
     kwargs_defaults = get_kwargs_defaults(argspec)
 
@@ -358,7 +358,7 @@ def memoize_with_ttl(ttl_secs=60 * 60 * 24):
     assert_gt(ttl_secs, 0, error_msg)
 
     def cache_fun(fun):
-        argspec = inspect.getargspec(fun)
+        argspec = inspection.getargspec(fun)
         arg_names = argspec.args
         kwargs_defaults = get_kwargs_defaults(argspec)
 


### PR DESCRIPTION
- test support of annotations by qcore.inspection.getargspec
- disallow keyword-only arguments, which previously were allowed but weren't
  handled correctly
- add tests for getargspec() on methods
- use inspection.getargspec for all caching functions, so that functions with
  annotations are supported, and add tests for this behavior

I'm rejecting functions with keyword-only arguments because there is no way to express their semantics without changing the return value of `getargspec()`, which assumes that defaults apply to the last names in the argument list. That assumption doesn't hold for functions like:

```
def f(x=3, *, y): ...
```

Python 3's `inspect` module gets around this by adding the `getfullargspec` function, which adds additional fields for keyword-only arguments and annotations. As of Python 3.3, the `inspect` module also provides the `Signature` object, which adds additional features. In order to support keyword-only arguments in qcore, we may need to backport one or the other of those to Python 2, but I'd prefer to leave that to another pull request.