### PR TITLE
add support for keyword-only args in qcore.caching

### DIFF
--- a/qcore/inspection.py
+++ b/qcore/inspection.py
@@ -135,7 +135,7 @@ def getargspec(func):
 
     This function works for Cythonized, non-cpdef functions, which expose argspec information but
     are not accepted by getargspec. It also works for Python 3 functions that use annotations, which
-    are simply ignoered. However, keyword-only arguments are not supported.
+    are simply ignored. However, keyword-only arguments are not supported.
 
     """
     if inspect.ismethod(func):

--- a/qcore/tests/test_caching.py
+++ b/qcore/tests/test_caching.py
@@ -389,11 +389,41 @@ def cached_fn_with_annotations(y: int, z: int=4) -> int:
     global x
     x += 1
     return y * z
+
+@memoize
+def cached_fn_with_kwonly_args(y, *, z):
+    global x
+    x += 1
+    return y * z
 """)
 except SyntaxError:
     pass
 else:
     memoize_fns.append(cached_fn_with_annotations)
+
+    def test_memoize_with_kwonly_args():
+        global x
+        x = 0
+        with AssertRaises(TypeError):
+            cached_fn_with_kwonly_args(1)
+        with AssertRaises(TypeError):
+            cached_fn_with_kwonly_args(1, 2)
+
+        assert_eq(0, x)
+
+        assert_eq(4, cached_fn_with_kwonly_args(2, z=2))
+        assert_eq(1, x)
+        assert_eq(4, cached_fn_with_kwonly_args(z=2, y=2))
+        assert_eq(1, x)
+
+        assert_eq(8, cached_fn_with_kwonly_args(2, z=4))
+        assert_eq(2, x)
+        assert_eq(8, cached_fn_with_kwonly_args(y=2, z=4))
+        assert_eq(2, x)
+
+        cached_fn_with_kwonly_args.clear_cache()
+        assert_eq(4, cached_fn_with_kwonly_args(2, z=2))
+        assert_eq(3, x)
 
 
 @memoize_with_ttl(ttl_secs=500)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Cython==0.24.1
+inspect2==0.1
 mock==2.0.0
 nose==1.3.7
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
         packages=find_packages(),
         package_data={'qcore': DATA_FILES},
         ext_modules=cythonize(EXTENSIONS),
-        install_requires=['Cython', 'setuptools', 'six'],
+        install_requires=['Cython', 'inspect2', 'setuptools', 'six'],
     )
 
     os.system('rm -rf ./build ./qcore.egg-info')


### PR DESCRIPTION
This paves the way towards fixing quora/asynq#32.

There's a minor bug here: given a function

    @memoize
    def f(x, *, y): pass

if you first call

    f(1, y=2)

to warm the cache and then call

    f(1, 2)

you won't get the error you should get because y is keyword-only. I don't think that's
a major problem.