### PR TITLE
qcore: add Cython as a requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ if __name__ == '__main__':
         packages=find_packages(),
         package_data={'qcore': DATA_FILES},
         ext_modules=cythonize(EXTENSIONS),
+        setup_requires=['Cython'],
         install_requires=['Cython', 'inspect2', 'setuptools', 'six'],
     )
 


### PR DESCRIPTION
This should help me to allow setup.py scripts to use Cython in them in theory.