### PR TITLE
qcore: don't need import cythonize during setup.py's egg_info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@
 
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
-from Cython.Build import cythonize
+
+import sys
 
 import codecs
 import os
@@ -41,6 +42,10 @@ if __name__ == '__main__':
     with codecs.open('./README.rst', encoding='utf-8') as f:
         long_description = f.read()
 
+    if 'egg_info' in sys.argv:
+        cythonize = lambda x: x
+    else:
+        from Cython.Build import cythonize
     setup(
         name='qcore',
         version=VERSION,


### PR DESCRIPTION
setuptools first does setup.py egg_info and then gets setup_requires
and install_requires and then installs those and then does setup.py
install
see:
https://github.com/pypa/pip/blob/5d951b2a94b9b3e07e3ed23b6d39a882f8f364aa/docs/reference/pip_install.rst#build-system-interface

for documentation

I tested this by taking a local copy of this setup.py and publish a
wheel to quora's internal pypi and then use tox on a module with qcore
as dependency. That didn't pass before. now it does.