### PR TITLE
fix pickling @retry functions

### DIFF
--- a/qcore/decorators.py
+++ b/qcore/decorators.py
@@ -247,9 +247,13 @@ def retry(exception_cls, max_tries=10, sleep=0.05):
         if not is_generator:
             # so that qcore.inspection.get_original_fn can retrieve the original function
             retry_fun.fn = fn
+            # Necessary for pickling of Cythonized functions to work. Cython's __reduce__
+            # method always returns the original name of the function.
+            retry_fun.__reduce__ = lambda: fn.__name__
             return retry_fun
         else:
             retry_generator_fun.fn = fn
+            retry_generator_fun.__reduce__ = lambda: fn.__name__
             return retry_generator_fun
     return outer
 

--- a/qcore/tests/test_decorators.py
+++ b/qcore/tests/test_decorators.py
@@ -63,6 +63,11 @@ class AnyOtherException(Exception):
     pass
 
 
+@retry(Exception)
+def retry_it():
+    pass
+
+
 class TestRetry(object):
     def create_generator_function(self, exception_type, max_tries):
         fn_body = mock.Mock()
@@ -84,6 +89,11 @@ class TestRetry(object):
             return fn_body(*args, **kwargs)
 
         return any_function, fn_body
+
+    def test_pickling(self):
+        for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(retry_it, protocol=protocol)
+            assert_is(retry_it, pickle.loads(pickled))
 
     def test_retry_passes_all_arguments(self):
         any_expected_exception_type = AnyException


### PR DESCRIPTION
The current implementation doesn't work with pickle due to a bug (or at least, odd design choice) of Cython: it always tries to pickle using the original name of the function, rather than the __name__ attribute. This is wrong for the qcore.retry, which uses a function called "retry_fun" to wrap the original function. I found that we can work around this by manually setting __reduce__ on the function object.