### PR TITLE
qcore: change pickle reduce implementation

### DIFF
--- a/qcore/enum.py
+++ b/qcore/enum.py
@@ -213,8 +213,8 @@ class EnumBase(six.with_metaclass(EnumType)):
     # This is necessary for things to unpickle correctly from Python 3 to 2, but does not work in 3.3
     # and lower.
     if sys.version_info >= (3, 4):
-        def __reduce__(self):
-            return (type(self).parse, (self.value,))
+        def __reduce_ex__(self, proto):
+            return self.__class__, (self.value,)
 
 
 class Enum(EnumBase):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ CYTHON_MODULES = ['helpers', 'microtime', 'events', 'decorators', 'caching', 'in
 DATA_FILES = ['%s.pxd' % module for module in CYTHON_MODULES]
 
 
-VERSION = '0.4.2'
+VERSION = '0.4.3'
 
 
 EXTENSIONS = [


### PR DESCRIPTION
This makes qcore enums pickle in the same way as enum.Enum, which
should make it easier to change away from qcore.Enum to enum.Enum.

Because this only changes dumps(), not loads(), there should be no
backward compatibility issue with pickles generated from previous
versions of qcore.