### PR TITLE
fix stub for `decorator_of_context_manager`

### DIFF
--- a/qcore/decorators.pyi
+++ b/qcore/decorators.pyi
@@ -50,5 +50,5 @@ def retry(
     sleep: float = ...,
 ) -> Callable[[_CallableT], _CallableT]: ...
 def decorator_of_context_manager(
-    ctxt: ContextManager[Any]
+    ctxt: Type[ContextManager[Any]]
 ) -> Callable[[_CallableT], _CallableT]: ...


### PR DESCRIPTION
It is intended to take a context manager class, not a context manager instance.