### PR TITLE
Build wheels in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,27 @@
 language: python
 
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7-dev"
+sudo: required
+services:
+  - docker
+env:
+  global:
+    - DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+matrix:
+  include:
+    - python: "2.7"
+      env: PYVER=cp27-cp27m
+    - python: "3.4"
+      env: PYVER=cp34-cp34m
+    - python: "3.5"
+      env: PYVER=cp35-cp35m
+    - python: "3.6"
+      env: PYVER=cp36-cp36m
+    - python: "3.7-dev"
+      env: PYVER=cp37-cp37m
 
 install:
-  - pip install .
-  - pip install -r requirements.txt
+  - docker pull $DOCKER_IMAGE
 
-script: python -m nose qcore/
+script:
+  - docker run --rm -e PYVER -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-wheels.sh
+  - ls wheelhouse/

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ if __name__ == '__main__':
 
             'Programming Language :: Python',
             'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -26,3 +26,7 @@ done
 # Install packages and test
 "${PYBIN}/pip" install qcore --no-index -f /io/wheelhouse
 (cd "$HOME"; "${PYBIN}/nosetests" qcore)
+
+if [[ "$PYVER" =~ "^cp36-" ]]; then
+    (cd "/io"; "${PYBIN}/mypy" qcore)
+fi

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -9,7 +9,7 @@ PYBIN=/opt/python/$PYVER/bin
 "${PYBIN}/pip" install -r /io/requirements.txt
 
 # Install dependencies of qcore
-"${PYBIN}/pip" install -U Cython tox
+"${PYBIN}/pip" install Cython tox
 
 "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e -x
+
+PYBIN=/opt/python/$PYVER/bin
+
+"${PYBIN}/pip" install --upgrade setuptools  # work around https://github.com/pypa/setuptools/issues/1086
+
+# Compile wheels
+"${PYBIN}/pip" install -r /io/requirements.txt
+
+# Install dependencies of qcore
+"${PYBIN}/pip" install -U Cython tox
+
+"${PYBIN}/pip" wheel /io/ -w wheelhouse/
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*-$PYVER-*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done
+
+# Copy plain wheels into the wheelhouse
+for whl in wheelhouse/*-py2.py3-*.whl; do
+    cp "$whl" /io/wheelhouse
+done
+
+# Install packages and test
+"${PYBIN}/pip" install qcore --no-index -f /io/wheelhouse
+(cd "$HOME"; "${PYBIN}/nosetests" qcore)


### PR DESCRIPTION
This updates the Travis config to build and test using manylinux wheels, similar to this PR for asynq: https://github.com/quora/asynq/pull/67

Two noteworthy changes from that asynq change:
- The addition of python3.7 support (since 3.7 was not out at the time of the asynq PR). The version of 3.7 in the manylinux Docker image is the final 3.7.0 release.
- Running the `mypy` command within the bash script. `tox` doesn't pick up on the python3.6 version available under `/opt/python/cp36-cp36m`, so I had to manually check for the python version and run `mypy` in the Travis script instead.