### PR TITLE
qcore: Add __prepare__ to some meta classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .arcconfig
 .tox/
 .mypy_cache/
+build/

--- a/qcore/disallow_inheritance.py
+++ b/qcore/disallow_inheritance.py
@@ -28,3 +28,9 @@ class DisallowInheritance(type):
                     (cls, cl_name)
                 raise TypeError(message)
         super(DisallowInheritance, self).__init__(cl_name, bases, namespace)
+
+    # Needed bcz of a six bug: https://github.com/benjaminp/six/issues/252
+    @classmethod
+    def __prepare__(cls, name, bases, **kwargs):
+        return {}
+

--- a/qcore/enum.py
+++ b/qcore/enum.py
@@ -90,6 +90,11 @@ class EnumType(type):
         member.__init__(value)
         return member
 
+    # Needed bcz of a six bug: https://github.com/benjaminp/six/issues/252
+    @classmethod
+    def __prepare__(cls, name, bases, **kwargs):
+        return {}
+
 
 class EnumBase(six.with_metaclass(EnumType)):
     _name_to_member = {}

--- a/qcore/events.py
+++ b/qcore/events.py
@@ -322,6 +322,11 @@ class EventHub(object):
         """Gets the ``repr`` representation of this object."""
         return '%s(%r)' % (self.__class__.__name__, self.__dict__)
 
+    # Needed bcz of a six bug: https://github.com/benjaminp/six/issues/252
+    @classmethod
+    def __prepare__(cls, name, bases, **kwargs):
+        return {}
+
 
 class EnumBasedEventHubType(type):
     """Metaclass for enum-based event hubs.
@@ -372,6 +377,11 @@ class EnumBasedEventHubType(type):
             # Members are removed from class, since EventHub anyway creates
             # similar instance members
             delattr(cls, 'on_' + name)
+
+    # Needed bcz of a six bug: https://github.com/benjaminp/six/issues/252
+    @classmethod
+    def __prepare__(cls, name, bases, **kwargs):
+        return {}
 
 
 class EnumBasedEventHub(six.with_metaclass(EnumBasedEventHubType, EventHub)):


### PR DESCRIPTION
Classes passed to `six.with_metaclass()` are expected to have a
`__prepare__` method to pass `tox` checks, which is not defined by
default in PY2 and not used.

See also <https://github.com/benjaminp/six/issues/252>.