### PR TITLE
asserts: Add startswith()/endswith() checks for strings

### DIFF
--- a/qcore/asserts.py
+++ b/qcore/asserts.py
@@ -49,11 +49,14 @@ __all__ = [
     "assert_in",
     "assert_not_in",
     "assert_in_with_tolerance",
-    "assert_is_substring",
-    "assert_is_not_substring",
     "assert_unordered_list_eq",
     "assert_raises",
     "AssertRaises",
+    # Strings
+    "assert_is_substring",
+    "assert_is_not_substring",
+    "assert_startswith",
+    "assert_endswith",
 ]
 
 
@@ -271,24 +274,6 @@ def assert_in_with_tolerance(obj, seq, tolerance, message=None, extra=None):
     assert False, _assert_fail_message(message, obj, seq, "is not in", extra)
 
 
-def assert_is_substring(substring, subject, message=None, extra=None):
-    """Raises an AssertionError if substring is not a substring of subject."""
-    assert (
-        (subject is not None)
-        and (substring is not None)
-        and (subject.find(substring) != -1)
-    ), _assert_fail_message(message, substring, subject, "is not in", extra)
-
-
-def assert_is_not_substring(substring, subject, message=None, extra=None):
-    """Raises an AssertionError if substring is a substring of subject."""
-    assert (
-        (subject is not None)
-        and (substring is not None)
-        and (subject.find(substring) == -1)
-    ), _assert_fail_message(message, substring, subject, "is in", extra)
-
-
 def assert_unordered_list_eq(expected, actual, message=None):
     """Raises an AssertionError if the objects contained
     in expected are not equal to the objects contained
@@ -366,3 +351,42 @@ class AssertRaises(object):
                 EXTRA_STR=(" (%s)" % self.extra) if self.extra is not None else "",
             )
         raise AssertionError(message)
+
+
+# ===================================================
+# Strings
+# ===================================================
+
+
+def assert_is_substring(substring, subject, message=None, extra=None):
+    """Raises an AssertionError if substring is not a substring of subject."""
+    assert (
+        (subject is not None)
+        and (substring is not None)
+        and (subject.find(substring) != -1)
+    ), _assert_fail_message(message, substring, subject, "is not in", extra)
+
+
+def assert_is_not_substring(substring, subject, message=None, extra=None):
+    """Raises an AssertionError if substring is a substring of subject."""
+    assert (
+        (subject is not None)
+        and (substring is not None)
+        and (subject.find(substring) == -1)
+    ), _assert_fail_message(message, substring, subject, "is in", extra)
+
+
+def assert_startswith(prefix, subject, message=None, extra=None):
+    """Raises an AssertionError if the subject string does not start with prefix."""
+    assert (
+        (type(subject) is str)
+        and (type(prefix) is str)
+        and (subject.startswith(prefix))
+    ), _assert_fail_message(message, subject, prefix, "does not start with", extra)
+
+
+def assert_endswith(suffix, subject, message=None, extra=None):
+    """Raises an AssertionError if the subject string does not end with suffix."""
+    assert (
+        (type(subject) is str) and (type(suffix) is str) and (subject.endswith(suffix))
+    ), _assert_fail_message(message, subject, suffix, "does not end with", extra)

--- a/qcore/asserts.pyi
+++ b/qcore/asserts.pyi
@@ -77,18 +77,6 @@ def assert_in_with_tolerance(
     message: Optional[str] = ...,
     extra: Optional[str] = ...,
 ) -> None: ...
-def assert_is_substring(
-    substring: str,
-    subject: str,
-    message: Optional[str] = ...,
-    extra: Optional[str] = ...,
-) -> None: ...
-def assert_is_not_substring(
-    substring: str,
-    subject: str,
-    message: Optional[str] = ...,
-    extra: Optional[str] = ...,
-) -> None: ...
 def assert_unordered_list_eq(
     expected: Iterable[Any], actual: Iterable[Any], message: Optional[str] = ...
 ) -> None: ...
@@ -107,3 +95,26 @@ class AssertRaises(object):
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> bool: ...
+
+# ===================================================
+# Strings
+# ===================================================
+
+def assert_is_substring(
+    substring: str,
+    subject: str,
+    message: Optional[str] = ...,
+    extra: Optional[str] = ...,
+) -> None: ...
+def assert_is_not_substring(
+    substring: str,
+    subject: str,
+    message: Optional[str] = ...,
+    extra: Optional[str] = ...,
+) -> None: ...
+def assert_startswith(
+    prefix: str, subject: str, message: Optional[str] = ..., extra: Optional[str] = ...
+) -> None: ...
+def assert_endswith(
+    suffix: str, subject: str, message: Optional[str] = ..., extra: Optional[str] = ...
+) -> None: ...

--- a/qcore/tests/test_asserts.py
+++ b/qcore/tests/test_asserts.py
@@ -19,8 +19,6 @@ from qcore.asserts import (
     assert_gt,
     assert_is,
     assert_is_not,
-    assert_is_substring,
-    assert_is_not_substring,
     assert_le,
     assert_lt,
     assert_ne,
@@ -30,6 +28,11 @@ from qcore.asserts import (
     assert_in,
     assert_dict_eq,
     assert_in_with_tolerance,
+    # Strings
+    assert_is_substring,
+    assert_is_not_substring,
+    assert_startswith,
+    assert_endswith,
 )
 
 
@@ -284,6 +287,8 @@ def test_complex_assertions():
             print(repr(e))
             raise
 
+
+def test_string_assertions():
     assert_is_substring("a", "bca")
     with AssertRaises(AssertionError):
         assert_is_substring("a", "bc")
@@ -291,6 +296,14 @@ def test_complex_assertions():
     assert_is_not_substring("a", "bc")
     with AssertRaises(AssertionError):
         assert_is_not_substring("a", "bca")
+
+    assert_startswith("a", "abc bcd")
+    with AssertRaises(AssertionError):
+        assert_startswith("b", "abc bcd")
+
+    assert_endswith("d", "abc bcd")
+    with AssertRaises(AssertionError):
+        assert_endswith("c", "abc bcd")
 
 
 class ExceptionWithValue(Exception):


### PR DESCRIPTION
Add `assrt_startswith()` and `assert_endswith()` checks for strings, to
make such tests easier, as alternate solutions to such checks either
require setting the needle in a local variable, or writing a boolean
assertion for result of `str.startswith()`/`str.endswith()`, which hide
the actual and expected values.

Test Plan:

Added unit tests.