### PR TITLE
Remove slow imports in testing.py

### DIFF
--- a/qcore/testing.py
+++ b/qcore/testing.py
@@ -47,18 +47,7 @@ __all__ = ["Anything", "GreaterEq"]
 import functools
 import inspect
 
-# avoid generating a dependency on mock and nose just for a constant and an exception class
-try:
-    import mock
-except ImportError:
-    TEST_PREFIX = "test"
-else:
-    TEST_PREFIX = mock.patch.TEST_PREFIX
-
-try:
-    from nose.plugins.skip import SkipTest
-except ImportError:
-    SkipTest = None
+TEST_PREFIX = "test"
 
 
 class _Anything(object):
@@ -111,10 +100,12 @@ def disabled(func_or_class):
     def decorate_func(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            if SkipTest is not None:
-                raise SkipTest
-            else:
+            try:
+                from nose.plugins.skip import SkipTest
+            except ImportError:
                 return None  # do nothing, the test will show up as passed
+            else:
+                raise SkipTest
 
         return wrapper
 


### PR DESCRIPTION
These are fairly slow to import and make importing qcore itself slow. For TEST_PREFIX, we can just use it directly—it's not going to change. SkipTest we can import only when it's needed, so we don't always have to import nose.