### PR TITLE
expose Utime newtype

### DIFF
--- a/qcore/microtime.py
+++ b/qcore/microtime.py
@@ -38,15 +38,19 @@ __all__ = [
     "utime",
     "true_utime",
     "execute_with_timeout",
+    "Utime",
 ]
 
 from functools import wraps
 import signal
 from time import time as _time
+from typing import NewType
 
 from . import inspection
 from .helpers import none, empty_tuple, empty_dict
 from .errors import TimeoutError, NotSupportedError
+
+Utime = NewType("Utime", int)
 
 
 MICROSECOND = 1

--- a/qcore/microtime.pyi
+++ b/qcore/microtime.pyi
@@ -3,6 +3,7 @@ from typing import (
     Callable,
     Iterable,
     Mapping,
+    NewType,
     Optional,
     SupportsInt,
     Type,
@@ -12,20 +13,22 @@ from types import TracebackType
 
 _T = TypeVar("_T")
 
-MICROSECOND: int
-MILLISECOND: int
-SECOND: int
-MINUTE: int
-HOUR: int
-DAY: int
-WEEK: int
-YEAR_APPROXIMATE: int
-MONTH_APPROXIMATE: int
+Utime = NewType("Utime", int)
+
+MICROSECOND: Utime
+MILLISECOND: Utime
+SECOND: Utime
+MINUTE: Utime
+HOUR: Utime
+DAY: Utime
+WEEK: Utime
+YEAR_APPROXIMATE: Utime
+MONTH_APPROXIMATE: Utime
 
 def utime_delta(
     *, days: int = ..., hours: int = ..., minutes: int = ..., seconds: int = ...
-) -> int: ...
-def get_time_offset() -> int: ...
+) -> Utime: ...
+def get_time_offset() -> Utime: ...
 def set_time_offset(offset: SupportsInt) -> None: ...
 def add_time_offset(offset: SupportsInt) -> None: ...
 
@@ -41,8 +44,8 @@ class TimeOffset(object):
         traceback: Optional[TracebackType],
     ) -> None: ...
 
-def utime() -> int: ...
-def true_utime() -> int: ...
+def utime() -> Utime: ...
+def true_utime() -> Utime: ...
 def execute_with_timeout(
     fn: Callable[..., _T],
     args: Optional[Iterable[Any]] = ...,

--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,11 @@ if __name__ == "__main__":
         package_data={"qcore": DATA_FILES},
         ext_modules=EXTENSIONS,
         setup_requires=["Cython"],
-        install_requires=["Cython", "inspect2", "setuptools", "six"],
+        install_requires=[
+            "Cython",
+            "inspect2",
+            "setuptools",
+            "six",
+            'typing; python_version < "3.5"',
+        ],
     )

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -9,7 +9,7 @@ PYBIN=/opt/python/$PYVER/bin
 "${PYBIN}/pip" install -r /io/requirements.txt
 
 # Install dependencies of qcore
-"${PYBIN}/pip" install Cython tox
+"${PYBIN}/pip" install Cython tox 'typing; python_version < "3.5"'
 
 "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 


### PR DESCRIPTION
We already use the Utime newtype internally, but we need to teach the typechecker that utime() returns a Utime.