### PR TITLE
prepare release 1.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+## 1.5.0
+
+* Fix stub for decorator_of_context_manager
+* Add qcore.Utime typing helper
+* Add clear() method to LRUCache
+* Fix stub for LRUCache
+
 ## 0.5.1
 * Add __prepare__ to some metaclasses to fix errors with six 1.11.0.
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ DATA_FILES = (
 )
 
 
-VERSION = "0.5.2"
+VERSION = "1.5.0"
 
 
 EXTENSIONS = [


### PR DESCRIPTION
We need to bump up the version significantly because we accidentally used a far too high version internally.