### PR TITLE
asserts: add AssertRaisesInstance and assert_raises_instance

### DIFF
--- a/qcore/asserts.pyi
+++ b/qcore/asserts.pyi
@@ -84,6 +84,9 @@ def assert_unordered_list_eq(
 def assert_raises(
     fn: Callable[[], Any], *expected_exception_types: Type[BaseException]
 ) -> None: ...
+def assert_raises_exception(
+    fn: Callable[[], Any], *expected_exception_instances: BaseException
+) -> None: ...
 
 class AssertRaises(object):
     expected_exception_types: Set[Type[BaseException]]
@@ -93,6 +96,20 @@ class AssertRaises(object):
         self, *expected_exception_types: Type[BaseException], extra: Optional[str] = ...
     ) -> None: ...
     def __enter__(self) -> AssertRaises: ...
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool: ...
+
+class AssertRaisesInstance(object):
+    expected_exception_types: Set[BaseException]
+    extra: Optional[str]
+    def __init__(
+        self, *expected_exception_instances: Type[BaseException], extra: Optional[str] = ...
+    ) -> None: ...
+    def __enter__(self) -> AssertRaisesInstance: ...
     def __exit__(
         self,
         exc_type: Optional[Type[BaseException]],


### PR DESCRIPTION
These make it easier to assert that a specific exception instance is
raised, compared to the alternative of using AssertRaises and having
an extra check on the message of the found exception.

Before:
  with AssertRaises(Exception) as assert_raises:
    raise Exception('error')
  assert_eq('error', str(assert_raises.expected_exception_found))

After:
  with AssertRaisesInstance(Exception('error')):
    raise Exception('error')