### PR TITLE
qcore.inspection: Remove cache from get_full_name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Remove broken caching from qcore.inspection.get_full_name
+
 ## 1.7.0
 
 * Update mypy version

--- a/qcore/inspection.py
+++ b/qcore/inspection.py
@@ -44,45 +44,28 @@ def get_original_fn(fn):
 def get_full_name(src):
     """Gets full class or function name."""
 
-    if hasattr(src, "_full_name_"):
-        return src._full_name_
     if hasattr(src, "is_decorator"):
         # Our own decorator or binder
         if hasattr(src, "decorator"):
             # Our own binder
-            _full_name_ = str(src.decorator)
-            # It's a short-living object, so we don't cache result
+            return str(src.decorator)
         else:
             # Our own decorator
-            _full_name_ = str(src)
-            try:
-                src._full_name_ = _full_name_
-            except AttributeError:
-                pass
-            except TypeError:
-                pass
+            return str(src)
     elif hasattr(src, "im_class"):
         # Bound method
         cls = src.im_class
-        _full_name_ = get_full_name(cls) + "." + src.__name__
-        # It's a short-living object, so we don't cache result
+        return get_full_name(cls) + "." + src.__name__
     elif hasattr(src, "__module__") and hasattr(src, "__name__"):
         # Func or class
-        _full_name_ = (
+        return (
             ("<unknown module>" if src.__module__ is None else src.__module__)
             + "."
             + src.__name__
         )
-        try:
-            src._full_name_ = _full_name_
-        except AttributeError:
-            pass
-        except TypeError:
-            pass
     else:
         # Something else
-        _full_name_ = str(get_original_fn(src))
-    return _full_name_
+        return str(get_original_fn(src))
 
 
 def get_function_call_str(fn, args, kwargs):


### PR DESCRIPTION
The cache is broken for classes: if we set the cache on a base class
and then try to get the full name of a child class, it will use the
base's value. We could fix this by checking only __dict__, but it seems
better to just avoid the cache. Callers should add caching if performance
is critical.
