### PR TITLE
pin Cython when building qcore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,6 @@ if __name__ == "__main__":
         packages=["qcore", "qcore.tests"],
         package_data={"qcore": DATA_FILES},
         ext_modules=EXTENSIONS,
-        setup_requires=["Cython"],
-        install_requires=["Cython"],
+        setup_requires=["Cython==0.29.36"],
+        install_requires=["Cython==0.29.36"],
     )

--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,5 @@ if __name__ == "__main__":
         package_data={"qcore": DATA_FILES},
         ext_modules=EXTENSIONS,
         setup_requires=["Cython==0.29.36"],
-        install_requires=["Cython==0.29.36"],
+        install_requires=["Cython"],
     )


### PR DESCRIPTION
the latest version of Cython (3.0.0) has backwards incompatible changes that prevents qcore from building properly now