### PR TITLE
asserts: add assert_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 .tox/
 .mypy_cache/
 build/
+.idea

--- a/qcore/asserts.py
+++ b/qcore/asserts.py
@@ -36,29 +36,29 @@ include:
 """
 
 __all__ = [
-    "assert_is",
-    "assert_is_not",
-    "assert_is_instance",
-    "assert_eq",
-    "assert_dict_eq",
-    "assert_ne",
-    "assert_gt",
-    "assert_ge",
-    "assert_lt",
-    "assert_le",
-    "assert_in",
-    "assert_not_in",
-    "assert_in_with_tolerance",
-    "assert_unordered_list_eq",
-    "assert_raises",
-    "AssertRaises",
-    # Strings
-    "assert_is_substring",
-    "assert_is_not_substring",
-    "assert_startswith",
-    "assert_endswith",
+	"assert_is",
+	"assert_is_not",
+	"assert_is_instance",
+	"assert_type",
+	"assert_eq",
+	"assert_dict_eq",
+	"assert_ne",
+	"assert_gt",
+	"assert_ge",
+	"assert_lt",
+	"assert_le",
+	"assert_in",
+	"assert_not_in",
+	"assert_in_with_tolerance",
+	"assert_unordered_list_eq",
+	"assert_raises",
+	"AssertRaises",
+	# Strings
+	"assert_is_substring",
+	"assert_is_not_substring",
+	"assert_startswith",
+	"assert_endswith",
 ]
-
 
 # The unittest.py testing framework checks for this variable in a module to
 # filter out stack frames from that module from the test output, in order to
@@ -70,298 +70,315 @@ import traceback
 
 from .inspection import get_full_name
 
-
 _number_types = (int, float, complex)
 
 
 def _assert_fail_message(message, expected, actual, comparison_str, extra):
-    if message:
-        return message
-    if extra:
-        return "%a %s %a (%s)" % (expected, comparison_str, actual, extra)
-    return "%a %s %a" % (expected, comparison_str, actual)
+	if message:
+		return message
+	if extra:
+		return "%a %s %a (%s)" % (expected, comparison_str, actual, extra)
+	return "%a %s %a" % (expected, comparison_str, actual)
 
 
 def assert_is(expected, actual, message=None, extra=None):
-    """Raises an AssertionError if expected is not actual."""
-    assert expected is actual, _assert_fail_message(
-        message, expected, actual, "is not", extra
-    )
+	"""Raises an AssertionError if expected is not actual."""
+	assert expected is actual, _assert_fail_message(
+		message, expected, actual, "is not", extra
+	)
 
 
 def assert_is_not(expected, actual, message=None, extra=None):
-    """Raises an AssertionError if expected is actual."""
-    assert expected is not actual, _assert_fail_message(
-        message, expected, actual, "is", extra
-    )
+	"""Raises an AssertionError if expected is actual."""
+	assert expected is not actual, _assert_fail_message(
+		message, expected, actual, "is", extra
+	)
 
 
 def assert_is_instance(value, types, message=None, extra=None):
-    """Raises an AssertionError if value is not an instance of type(s)."""
-    assert isinstance(value, types), _assert_fail_message(
-        message, value, types, "is not an instance of", extra
-    )
+	"""Raises an AssertionError if value is not an instance of type(s)."""
+	assert isinstance(value, types), _assert_fail_message(
+		message, value, types, "is not an instance of", extra
+	)
+
+
+def assert_type(obj, expected_type, msg=None):
+	"""
+    Assert that an object is of a specific type.
+
+    Args:
+        obj: The object to check the type of.
+        expected_type: The expected type (e.g., int, str, list, etc.).
+        msg (optional): An optional error message to display if the assertion fails.
+
+    Raises:
+        AssertionError: If the object is not of the expected type.
+    """
+	if not isinstance(obj, expected_type):
+		if msg is None:
+			msg = f"Expected type {expected_type}, but got type {type(obj)}"
+		raise AssertionError(msg)
 
 
 def assert_eq(expected, actual, message=None, tolerance=None, extra=None):
-    """Raises an AssertionError if expected != actual.
+	"""Raises an AssertionError if expected != actual.
 
     If tolerance is specified, raises an AssertionError if either
     - expected or actual isn't a number, or
     - the difference between expected and actual is larger than the tolerance.
 
     """
-    if tolerance is None:
-        assert expected == actual, _assert_fail_message(
-            message, expected, actual, "!=", extra
-        )
-    else:
-        assert isinstance(tolerance, _number_types), (
-            "tolerance parameter to assert_eq must be a number: %a" % tolerance
-        )
-        assert isinstance(expected, _number_types) and isinstance(
-            actual, _number_types
-        ), "parameters must be numbers when tolerance is specified: %a, %a" % (
-            expected,
-            actual,
-        )
-
-        diff = abs(expected - actual)
-        assert diff <= tolerance, _assert_fail_message(
-            message, expected, actual, "is more than %a away from" % tolerance, extra
-        )
+	if tolerance is None:
+		assert expected == actual, _assert_fail_message(
+			message, expected, actual, "!=", extra
+		)
+	else:
+		assert isinstance(tolerance, _number_types), (
+										"tolerance parameter to assert_eq must be a number: %a" % tolerance
+		)
+		assert isinstance(expected, _number_types) and isinstance(
+			actual, _number_types
+		), "parameters must be numbers when tolerance is specified: %a, %a" % (
+			expected,
+			actual,
+		)
+		
+		diff = abs(expected - actual)
+		assert diff <= tolerance, _assert_fail_message(
+			message, expected, actual, "is more than %a away from" % tolerance, extra
+		)
 
 
 def _dict_path_string(path):
-    if len(path) == 0:
-        return "(root)"
-    return "->".join(map(ascii, path))
+	if len(path) == 0:
+		return "(root)"
+	return "->".join(map(ascii, path))
 
 
 def _to_concrete_dict(value):
-    """Convert dict-subclass instances to concrete dict instances."""
-    return dict(value) if isinstance(value, dict) and type(value) is not dict else value
+	"""Convert dict-subclass instances to concrete dict instances."""
+	return dict(value) if isinstance(value, dict) and type(value) is not dict else value
 
 
 def assert_dict_eq(expected, actual, number_tolerance=None, dict_path=[]):
-    """Asserts that two dictionaries are equal, producing a custom message if they are not."""
-    assert_is_instance(expected, dict)
-    assert_is_instance(actual, dict)
-
-    expected_keys = set(expected.keys())
-    actual_keys = set(actual.keys())
-    assert expected_keys <= actual_keys, "Actual dict at %s is missing keys: %a" % (
-        _dict_path_string(dict_path),
-        expected_keys - actual_keys,
-    )
-    assert actual_keys <= expected_keys, "Actual dict at %s has extra keys: %a" % (
-        _dict_path_string(dict_path),
-        actual_keys - expected_keys,
-    )
-
-    for key in expected_keys:
-        key_path = dict_path + [key]
-
-        expected_value = _to_concrete_dict(expected[key])
-        actual_value = _to_concrete_dict(actual[key])
-
-        assert_is_instance(
-            actual_value,
-            type(expected_value),
-            extra="Types don't match for %s" % _dict_path_string(key_path),
-        )
-        assert_is_instance(
-            expected_value,
-            type(actual_value),
-            extra="Types don't match for %s" % _dict_path_string(key_path),
-        )
-
-        if isinstance(actual_value, dict):
-            assert_dict_eq(
-                expected_value,
-                actual_value,
-                number_tolerance=number_tolerance,
-                dict_path=key_path,
-            )
-        elif isinstance(actual_value, _number_types):
-            assert_eq(
-                expected_value,
-                actual_value,
-                extra="Value doesn't match for %s" % _dict_path_string(key_path),
-                tolerance=number_tolerance,
-            )
-        else:
-            assert_eq(
-                expected_value,
-                actual_value,
-                extra="Value doesn't match for %s" % _dict_path_string(key_path),
-            )
+	"""Asserts that two dictionaries are equal, producing a custom message if they are not."""
+	assert_is_instance(expected, dict)
+	assert_is_instance(actual, dict)
+	
+	expected_keys = set(expected.keys())
+	actual_keys = set(actual.keys())
+	assert expected_keys <= actual_keys, "Actual dict at %s is missing keys: %a" % (
+		_dict_path_string(dict_path),
+		expected_keys - actual_keys,
+	)
+	assert actual_keys <= expected_keys, "Actual dict at %s has extra keys: %a" % (
+		_dict_path_string(dict_path),
+		actual_keys - expected_keys,
+	)
+	
+	for key in expected_keys:
+		key_path = dict_path + [key]
+		
+		expected_value = _to_concrete_dict(expected[key])
+		actual_value = _to_concrete_dict(actual[key])
+		
+		assert_is_instance(
+			actual_value,
+			type(expected_value),
+			extra="Types don't match for %s" % _dict_path_string(key_path),
+		)
+		assert_is_instance(
+			expected_value,
+			type(actual_value),
+			extra="Types don't match for %s" % _dict_path_string(key_path),
+		)
+		
+		if isinstance(actual_value, dict):
+			assert_dict_eq(
+				expected_value,
+				actual_value,
+				number_tolerance=number_tolerance,
+				dict_path=key_path,
+			)
+		elif isinstance(actual_value, _number_types):
+			assert_eq(
+				expected_value,
+				actual_value,
+				extra="Value doesn't match for %s" % _dict_path_string(key_path),
+				tolerance=number_tolerance,
+			)
+		else:
+			assert_eq(
+				expected_value,
+				actual_value,
+				extra="Value doesn't match for %s" % _dict_path_string(key_path),
+			)
 
 
 def assert_ne(expected, actual, message=None, tolerance=None, extra=None):
-    """Raises an AssertionError if expected == actual.
+	"""Raises an AssertionError if expected == actual.
 
     If tolerance is specified, raises an AssertionError if either
     - expected or actual isn't a number, or
     - the difference between expected and actual is smaller than the tolerance.
 
     """
-    if tolerance is None:
-        assert expected != actual, _assert_fail_message(
-            message, expected, actual, "==", extra
-        )
-    else:
-        assert isinstance(tolerance, _number_types), (
-            "tolerance parameter to assert_eq must be a number: %a" % tolerance
-        )
-        assert isinstance(expected, _number_types) and isinstance(
-            actual, _number_types
-        ), "parameters must be numbers when tolerance is specified: %a, %a" % (
-            expected,
-            actual,
-        )
-
-        diff = abs(expected - actual)
-        assert diff > tolerance, _assert_fail_message(
-            message, expected, actual, "is less than %a away from" % tolerance, extra
-        )
+	if tolerance is None:
+		assert expected != actual, _assert_fail_message(
+			message, expected, actual, "==", extra
+		)
+	else:
+		assert isinstance(tolerance, _number_types), (
+										"tolerance parameter to assert_eq must be a number: %a" % tolerance
+		)
+		assert isinstance(expected, _number_types) and isinstance(
+			actual, _number_types
+		), "parameters must be numbers when tolerance is specified: %a, %a" % (
+			expected,
+			actual,
+		)
+		
+		diff = abs(expected - actual)
+		assert diff > tolerance, _assert_fail_message(
+			message, expected, actual, "is less than %a away from" % tolerance, extra
+		)
 
 
 def assert_gt(left, right, message=None, extra=None):
-    """Raises an AssertionError if left_hand <= right_hand."""
-    assert left > right, _assert_fail_message(message, left, right, "<=", extra)
+	"""Raises an AssertionError if left_hand <= right_hand."""
+	assert left > right, _assert_fail_message(message, left, right, "<=", extra)
 
 
 def assert_ge(left, right, message=None, extra=None):
-    """Raises an AssertionError if left_hand < right_hand."""
-    assert left >= right, _assert_fail_message(message, left, right, "<", extra)
+	"""Raises an AssertionError if left_hand < right_hand."""
+	assert left >= right, _assert_fail_message(message, left, right, "<", extra)
 
 
 def assert_lt(left, right, message=None, extra=None):
-    """Raises an AssertionError if left_hand >= right_hand."""
-    assert left < right, _assert_fail_message(message, left, right, ">=", extra)
+	"""Raises an AssertionError if left_hand >= right_hand."""
+	assert left < right, _assert_fail_message(message, left, right, ">=", extra)
 
 
 def assert_le(left, right, message=None, extra=None):
-    """Raises an AssertionError if left_hand > right_hand."""
-    assert left <= right, _assert_fail_message(message, left, right, ">", extra)
+	"""Raises an AssertionError if left_hand > right_hand."""
+	assert left <= right, _assert_fail_message(message, left, right, ">", extra)
 
 
 def assert_in(obj, seq, message=None, extra=None):
-    """Raises an AssertionError if obj is not in seq."""
-    assert obj in seq, _assert_fail_message(message, obj, seq, "is not in", extra)
+	"""Raises an AssertionError if obj is not in seq."""
+	assert obj in seq, _assert_fail_message(message, obj, seq, "is not in", extra)
 
 
 def assert_not_in(obj, seq, message=None, extra=None):
-    """Raises an AssertionError if obj is in iter."""
-    # for very long strings, provide a truncated error
-    if isinstance(seq, str) and obj in seq and len(seq) > 200:
-        index = seq.find(obj)
-        start_index = index - 50
-        if start_index > 0:
-            truncated = "(truncated) ..."
-        else:
-            truncated = ""
-            start_index = 0
-        end_index = index + len(obj) + 50
-        truncated += seq[start_index:end_index]
-        if end_index < len(seq):
-            truncated += "... (truncated)"
-        assert False, _assert_fail_message(message, obj, truncated, "is in", extra)
-    assert obj not in seq, _assert_fail_message(message, obj, seq, "is in", extra)
+	"""Raises an AssertionError if obj is in iter."""
+	# for very long strings, provide a truncated error
+	if isinstance(seq, str) and obj in seq and len(seq) > 200:
+		index = seq.find(obj)
+		start_index = index - 50
+		if start_index > 0:
+			truncated = "(truncated) ..."
+		else:
+			truncated = ""
+			start_index = 0
+		end_index = index + len(obj) + 50
+		truncated += seq[start_index:end_index]
+		if end_index < len(seq):
+			truncated += "... (truncated)"
+		assert False, _assert_fail_message(message, obj, truncated, "is in", extra)
+	assert obj not in seq, _assert_fail_message(message, obj, seq, "is in", extra)
 
 
 def assert_in_with_tolerance(obj, seq, tolerance, message=None, extra=None):
-    """Raises an AssertionError if obj is not in seq using assert_eq cmp."""
-    for i in seq:
-        try:
-            assert_eq(obj, i, tolerance=tolerance, message=message, extra=extra)
-            return
-        except AssertionError:
-            pass
-    assert False, _assert_fail_message(message, obj, seq, "is not in", extra)
+	"""Raises an AssertionError if obj is not in seq using assert_eq cmp."""
+	for i in seq:
+		try:
+			assert_eq(obj, i, tolerance=tolerance, message=message, extra=extra)
+			return
+		except AssertionError:
+			pass
+	assert False, _assert_fail_message(message, obj, seq, "is not in", extra)
 
 
 def assert_unordered_list_eq(expected, actual, message=None):
-    """Raises an AssertionError if the objects contained
+	"""Raises an AssertionError if the objects contained
     in expected are not equal to the objects contained
     in actual  without regard to their order.
 
     This takes quadratic time in the umber of elements in actual; don't use it for very long lists.
 
     """
-    missing_in_actual = []
-    missing_in_expected = list(actual)
-    for x in expected:
-        try:
-            missing_in_expected.remove(x)
-        except ValueError:
-            missing_in_actual.append(x)
-
-    if missing_in_actual or missing_in_expected:
-        if not message:
-            message = (
-                "%a not equal to %a; missing items: %a in expected, %a in actual."
-                % (expected, actual, missing_in_expected, missing_in_actual)
-            )
-        assert False, message
+	missing_in_actual = []
+	missing_in_expected = list(actual)
+	for x in expected:
+		try:
+			missing_in_expected.remove(x)
+		except ValueError:
+			missing_in_actual.append(x)
+	
+	if missing_in_actual or missing_in_expected:
+		if not message:
+			message = (
+											"%a not equal to %a; missing items: %a in expected, %a in actual."
+											% (expected, actual, missing_in_expected, missing_in_actual)
+			)
+		assert False, message
 
 
 def assert_raises(fn, *expected_exception_types):
-    """Raises an AssertionError if calling fn does not raise one of the expected_exception-types."""
-    with AssertRaises(*expected_exception_types):
-        fn()
+	"""Raises an AssertionError if calling fn does not raise one of the expected_exception-types."""
+	with AssertRaises(*expected_exception_types):
+		fn()
 
 
 class AssertRaises:
-    """With-context that asserts that the code within the context raises the specified exception."""
-
-    def __init__(self, *expected_exception_types, **kwargs):
-        # when you don't specify the exception expected, it's easy to write buggy tests that appear
-        # to pass but actually throw an exception different from the expected one
-        assert (
-            len(expected_exception_types) >= 1
-        ), "You must specify the exception type when using AssertRaises"
-        self.expected_exception_types = set(expected_exception_types)
-        self.expected_exception_found = None
-        self.extra = kwargs.pop("extra", None)
-        assert_eq({}, kwargs)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type in self.expected_exception_types:
-            # Return True to suppress the Exception if the type matches. For details,
-            # see: http://docs.python.org/release/2.5.2/lib/typecontextmanager.html
-
-            self.expected_exception_found = exc_val
-            return True
-
-        for t in self.expected_exception_types:
-            if isinstance(exc_val, t):
-                self.expected_exception_found = exc_val
-                return True
-
-        expected = ", ".join(map(get_full_name, self.expected_exception_types))
-
-        if exc_type is None:
-            message = "No exception raised, but expected: %s" % expected
-            if self.extra is not None:
-                message += " (%s)" % self.extra
-        else:
-            template = (
-                "{TYPE}: {VAL} is raised, but expected:"
-                " {EXPECTED}{EXTRA_STR}\n\n{STACK}"
-            )
-            message = template.format(
-                TYPE=get_full_name(exc_type),
-                VAL=exc_val,
-                EXPECTED=expected,
-                STACK="".join(traceback.format_tb(exc_tb)),
-                EXTRA_STR=(" (%s)" % self.extra) if self.extra is not None else "",
-            )
-        raise AssertionError(message)
+	"""With-context that asserts that the code within the context raises the specified exception."""
+	
+	def __init__(self, *expected_exception_types, **kwargs):
+		# when you don't specify the exception expected, it's easy to write buggy tests that appear
+		# to pass but actually throw an exception different from the expected one
+		assert (
+										len(expected_exception_types) >= 1
+		), "You must specify the exception type when using AssertRaises"
+		self.expected_exception_types = set(expected_exception_types)
+		self.expected_exception_found = None
+		self.extra = kwargs.pop("extra", None)
+		assert_eq({}, kwargs)
+	
+	def __enter__(self):
+		return self
+	
+	def __exit__(self, exc_type, exc_val, exc_tb):
+		if exc_type in self.expected_exception_types:
+			# Return True to suppress the Exception if the type matches. For details,
+			# see: http://docs.python.org/release/2.5.2/lib/typecontextmanager.html
+			
+			self.expected_exception_found = exc_val
+			return True
+		
+		for t in self.expected_exception_types:
+			if isinstance(exc_val, t):
+				self.expected_exception_found = exc_val
+				return True
+		
+		expected = ", ".join(map(get_full_name, self.expected_exception_types))
+		
+		if exc_type is None:
+			message = "No exception raised, but expected: %s" % expected
+			if self.extra is not None:
+				message += " (%s)" % self.extra
+		else:
+			template = (
+				"{TYPE}: {VAL} is raised, but expected:"
+				" {EXPECTED}{EXTRA_STR}\n\n{STACK}"
+			)
+			message = template.format(
+				TYPE=get_full_name(exc_type),
+				VAL=exc_val,
+				EXPECTED=expected,
+				STACK="".join(traceback.format_tb(exc_tb)),
+				EXTRA_STR=(" (%s)" % self.extra) if self.extra is not None else "",
+			)
+		raise AssertionError(message)
 
 
 # ===================================================
@@ -370,34 +387,34 @@ class AssertRaises:
 
 
 def assert_is_substring(substring, subject, message=None, extra=None):
-    """Raises an AssertionError if substring is not a substring of subject."""
-    assert (
-        (subject is not None)
-        and (substring is not None)
-        and (subject.find(substring) != -1)
-    ), _assert_fail_message(message, substring, subject, "is not in", extra)
+	"""Raises an AssertionError if substring is not a substring of subject."""
+	assert (
+									(subject is not None)
+									and (substring is not None)
+									and (subject.find(substring) != -1)
+	), _assert_fail_message(message, substring, subject, "is not in", extra)
 
 
 def assert_is_not_substring(substring, subject, message=None, extra=None):
-    """Raises an AssertionError if substring is a substring of subject."""
-    assert (
-        (subject is not None)
-        and (substring is not None)
-        and (subject.find(substring) == -1)
-    ), _assert_fail_message(message, substring, subject, "is in", extra)
+	"""Raises an AssertionError if substring is a substring of subject."""
+	assert (
+									(subject is not None)
+									and (substring is not None)
+									and (subject.find(substring) == -1)
+	), _assert_fail_message(message, substring, subject, "is in", extra)
 
 
 def assert_startswith(prefix, subject, message=None, extra=None):
-    """Raises an AssertionError if the subject string does not start with prefix."""
-    assert (
-        (type(subject) is str)
-        and (type(prefix) is str)
-        and (subject.startswith(prefix))
-    ), _assert_fail_message(message, subject, prefix, "does not start with", extra)
+	"""Raises an AssertionError if the subject string does not start with prefix."""
+	assert (
+									(type(subject) is str)
+									and (type(prefix) is str)
+									and (subject.startswith(prefix))
+	), _assert_fail_message(message, subject, prefix, "does not start with", extra)
 
 
 def assert_endswith(suffix, subject, message=None, extra=None):
-    """Raises an AssertionError if the subject string does not end with suffix."""
-    assert (
-        (type(subject) is str) and (type(suffix) is str) and (subject.endswith(suffix))
-    ), _assert_fail_message(message, subject, suffix, "does not end with", extra)
+	"""Raises an AssertionError if the subject string does not end with suffix."""
+	assert (
+									(type(subject) is str) and (type(suffix) is str) and (subject.endswith(suffix))
+	), _assert_fail_message(message, subject, suffix, "does not end with", extra)

--- a/qcore/asserts.pyi
+++ b/qcore/asserts.pyi
@@ -1,150 +1,193 @@
 from types import TracebackType
 from typing import (
-    Any,
-    Callable,
-    Container,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
+	Any,
+	Callable,
+	Container,
+	Dict,
+	Iterable,
+	List,
+	Optional,
+	Set,
+	Tuple,
+	Type,
+	Union,
 )
 
 _Numeric = Union[int, float, complex]
 
+
 def assert_is(
-    expected: Any,
-    actual: Any,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_is_not(
-    expected: Any,
-    actual: Any,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_is_instance(
-    value: Any,
-    types: Union[Type[Any], Tuple[Union[Type[Any], Tuple[Any, ...]], ...]],
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_eq(
-    expected: Any,
-    actual: Any,
-    message: Optional[str] = ...,
-    tolerance: Optional[_Numeric] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_dict_eq(
-    expected: Dict[Any, Any],
-    actual: Dict[Any, Any],
-    number_tolerance: Optional[_Numeric] = ...,
-    dict_path: List[Any] = ...,
-) -> None: ...
-def assert_ne(
-    expected: Any,
-    actual: Any,
-    message: Optional[str] = ...,
-    tolerance: Optional[_Numeric] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_gt(
-    expected: Any,
-    actual: Any,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_ge(
-    expected: Any,
-    actual: Any,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_lt(
-    expected: Any,
-    actual: Any,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_le(
-    expected: Any,
-    actual: Any,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_in(
-    expected: Any,
-    actual: Container[Any],
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_not_in(
-    expected: Any,
-    actual: Container[Any],
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_in_with_tolerance(
-    expected: Any,
-    actual: Container[Any],
-    tolerance: _Numeric,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
-) -> None: ...
-def assert_unordered_list_eq(
-    expected: Iterable[Any], actual: Iterable[Any], message: Optional[str] = ...
-) -> None: ...
-def assert_raises(
-    fn: Callable[[], Any], *expected_exception_types: Type[BaseException]
+								expected: Any,
+								actual: Any,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
 ) -> None: ...
 
+
+def assert_is_not(
+								expected: Any,
+								actual: Any,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_is_instance(
+								value: Any,
+								types: Union[Type[Any], Tuple[Union[Type[Any], Tuple[Any, ...]], ...]],
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_eq(
+								expected: Any,
+								actual: Any,
+								message: Optional[str] = ...,
+								tolerance: Optional[_Numeric] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_dict_eq(
+								expected: Dict[Any, Any],
+								actual: Dict[Any, Any],
+								number_tolerance: Optional[_Numeric] = ...,
+								dict_path: List[Any] = ...,
+) -> None: ...
+
+
+def assert_ne(
+								expected: Any,
+								actual: Any,
+								message: Optional[str] = ...,
+								tolerance: Optional[_Numeric] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_gt(
+								expected: Any,
+								actual: Any,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_ge(
+								expected: Any,
+								actual: Any,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_lt(
+								expected: Any,
+								actual: Any,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_le(
+								expected: Any,
+								actual: Any,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_in(
+								expected: Any,
+								actual: Container[Any],
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_not_in(
+								expected: Any,
+								actual: Container[Any],
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_in_with_tolerance(
+								expected: Any,
+								actual: Container[Any],
+								tolerance: _Numeric,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
+) -> None: ...
+
+
+def assert_unordered_list_eq(
+								expected: Iterable[Any], actual: Iterable[Any], message: Optional[str] = ...
+) -> None: ...
+
+
+def assert_raises(
+								fn: Callable[[], Any], *expected_exception_types: Type[BaseException]
+) -> None: ...
+
+
 class AssertRaises:
-    expected_exception_types: Set[Type[BaseException]]
-    expected_exception_found: Any
-    extra: Optional[str]
-    def __init__(
-        self,
-        *expected_exception_types: Type[BaseException],
-        extra: Optional[object] = ...,
-    ) -> None: ...
-    def __enter__(self) -> AssertRaises: ...
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ) -> bool: ...
+	expected_exception_types: Set[Type[BaseException]]
+	expected_exception_found: Any
+	extra: Optional[str]
+	
+	def __init__(
+									self,
+									*expected_exception_types: Type[BaseException],
+									extra: Optional[object] = ...,
+	) -> None: ...
+	
+	def __enter__(self) -> AssertRaises: ...
+	
+	def __exit__(
+									self,
+									exc_type: Optional[Type[BaseException]],
+									exc_val: Optional[BaseException],
+									exc_tb: Optional[TracebackType],
+	) -> bool: ...
+
 
 # ===================================================
 # Strings
 # ===================================================
 
 def assert_is_substring(
-    substring: str,
-    subject: str,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
+								substring: str,
+								subject: str,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
 ) -> None: ...
+
+
 def assert_is_not_substring(
-    substring: str,
-    subject: str,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
+								substring: str,
+								subject: str,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
 ) -> None: ...
+
+
 def assert_startswith(
-    prefix: str,
-    subject: str,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
+								prefix: str,
+								subject: str,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
 ) -> None: ...
+
+
 def assert_endswith(
-    suffix: str,
-    subject: str,
-    message: Optional[str] = ...,
-    extra: Optional[object] = ...,
+								suffix: str,
+								subject: str,
+								message: Optional[str] = ...,
+								extra: Optional[object] = ...,
 ) -> None: ...
+
+
+def assert_type(obj, expected_type, msg=None) -> None: ...

--- a/qcore/tests/test_asserts.py
+++ b/qcore/tests/test_asserts.py
@@ -16,361 +16,377 @@
 from collections import defaultdict
 
 from qcore.asserts import (
-    assert_eq,
-    assert_ge,
-    assert_gt,
-    assert_is,
-    assert_is_not,
-    assert_le,
-    assert_lt,
-    assert_ne,
-    assert_unordered_list_eq,
-    AssertRaises,
-    assert_not_in,
-    assert_in,
-    assert_dict_eq,
-    assert_in_with_tolerance,
-    # Strings
-    assert_is_substring,
-    assert_is_not_substring,
-    assert_startswith,
-    assert_endswith,
+	assert_eq,
+	assert_ge,
+	assert_gt,
+	assert_is,
+	assert_is_not,
+	assert_le,
+	assert_lt,
+	assert_ne,
+	assert_unordered_list_eq,
+	AssertRaises,
+	assert_not_in,
+	assert_in,
+	assert_dict_eq,
+	assert_in_with_tolerance,
+	# Strings
+	assert_is_substring,
+	assert_is_not_substring,
+	assert_startswith,
+	assert_endswith, assert_type,
 )
 
 
 def test_assert_eq():
-    assert_eq(1, 1)
-    assert_eq("abc", "abc")
-    assert_eq(None, None)
-    assert_eq(1.0004, 1.0005, tolerance=0.001)
-    assert_eq(1, 1.0, tolerance=0.001)
+	assert_eq(1, 1)
+	assert_eq("abc", "abc")
+	assert_eq(None, None)
+	assert_eq(1.0004, 1.0005, tolerance=0.001)
+	assert_eq(1, 1.0, tolerance=0.001)
 
 
 def test_assert_eq_failures():
-    with AssertRaises(AssertionError):
-        assert_eq(1, 2)
-    with AssertRaises(AssertionError):
-        assert_eq("abc", "abcd")
-    with AssertRaises(AssertionError):
-        assert_eq(None, 1)
-    with AssertRaises(AssertionError):
-        assert_eq(1.0004, 1.0005, tolerance=0.00001)
-    with AssertRaises(AssertionError):
-        assert_eq(1, 1.01, tolerance=0.001)
-
-    # type errors
-    with AssertRaises(AssertionError):
-        assert_eq("s", 1, tolerance=0.1)
-    with AssertRaises(AssertionError):
-        assert_eq(None, 1, tolerance=0.1)
-    with AssertRaises(AssertionError):
-        assert_eq(1, 1, tolerance="s")
+	with AssertRaises(AssertionError):
+		assert_eq(1, 2)
+	with AssertRaises(AssertionError):
+		assert_eq("abc", "abcd")
+	with AssertRaises(AssertionError):
+		assert_eq(None, 1)
+	with AssertRaises(AssertionError):
+		assert_eq(1.0004, 1.0005, tolerance=0.00001)
+	with AssertRaises(AssertionError):
+		assert_eq(1, 1.01, tolerance=0.001)
+	
+	# type errors
+	with AssertRaises(AssertionError):
+		assert_eq("s", 1, tolerance=0.1)
+	with AssertRaises(AssertionError):
+		assert_eq(None, 1, tolerance=0.1)
+	with AssertRaises(AssertionError):
+		assert_eq(1, 1, tolerance="s")
 
 
 def test_assert_ordering():
-    # ints
-    assert_gt(2, 1)
-    with AssertRaises(AssertionError):
-        assert_gt(1, 1)
-    with AssertRaises(AssertionError):
-        assert_gt(0, 1)
-
-    assert_ge(2, 1)
-    assert_ge(1, 1)
-    with AssertRaises(AssertionError):
-        assert_ge(0, 1)
-
-    with AssertRaises(AssertionError):
-        assert_lt(2, 1)
-    with AssertRaises(AssertionError):
-        assert_lt(1, 1)
-    assert_lt(0, 1)
-
-    with AssertRaises(AssertionError):
-        assert_le(2, 1)
-    assert_le(1, 1)
-    assert_lt(0, 1)
-
-    # floats (tolerance isn't supported)
-    assert_gt(2.5, 1.5)
-    with AssertRaises(AssertionError):
-        assert_gt(1.5, 1.5)
-    with AssertRaises(AssertionError):
-        assert_gt(0.5, 1.5)
-
-    assert_ge(2.5, 1.5)
-    assert_ge(1.5, 1.5)
-    with AssertRaises(AssertionError):
-        assert_ge(0.5, 1.5)
-
-    with AssertRaises(AssertionError):
-        assert_lt(2.5, 1.5)
-    with AssertRaises(AssertionError):
-        assert_lt(1.5, 1.5)
-    assert_lt(0.5, 1.5)
-
-    with AssertRaises(AssertionError):
-        assert_le(2.5, 1.5)
-    assert_le(1.5, 1.5)
-    assert_lt(0.5, 1.5)
-
-    # strings
-    assert_gt("c", "b")
-    with AssertRaises(AssertionError):
-        assert_gt("b", "b")
-    with AssertRaises(AssertionError):
-        assert_gt("a", "b")
-
-    assert_ge("c", "b")
-    assert_ge("b", "b")
-    with AssertRaises(AssertionError):
-        assert_ge("a", "b")
-
-    with AssertRaises(AssertionError):
-        assert_lt("c", "b")
-    with AssertRaises(AssertionError):
-        assert_lt("b", "b")
-    assert_lt("a", "b")
-
-    with AssertRaises(AssertionError):
-        assert_le("c", "b")
-    assert_le("b", "b")
-    assert_lt("a", "b")
+	# ints
+	assert_gt(2, 1)
+	with AssertRaises(AssertionError):
+		assert_gt(1, 1)
+	with AssertRaises(AssertionError):
+		assert_gt(0, 1)
+	
+	assert_ge(2, 1)
+	assert_ge(1, 1)
+	with AssertRaises(AssertionError):
+		assert_ge(0, 1)
+	
+	with AssertRaises(AssertionError):
+		assert_lt(2, 1)
+	with AssertRaises(AssertionError):
+		assert_lt(1, 1)
+	assert_lt(0, 1)
+	
+	with AssertRaises(AssertionError):
+		assert_le(2, 1)
+	assert_le(1, 1)
+	assert_lt(0, 1)
+	
+	# floats (tolerance isn't supported)
+	assert_gt(2.5, 1.5)
+	with AssertRaises(AssertionError):
+		assert_gt(1.5, 1.5)
+	with AssertRaises(AssertionError):
+		assert_gt(0.5, 1.5)
+	
+	assert_ge(2.5, 1.5)
+	assert_ge(1.5, 1.5)
+	with AssertRaises(AssertionError):
+		assert_ge(0.5, 1.5)
+	
+	with AssertRaises(AssertionError):
+		assert_lt(2.5, 1.5)
+	with AssertRaises(AssertionError):
+		assert_lt(1.5, 1.5)
+	assert_lt(0.5, 1.5)
+	
+	with AssertRaises(AssertionError):
+		assert_le(2.5, 1.5)
+	assert_le(1.5, 1.5)
+	assert_lt(0.5, 1.5)
+	
+	# strings
+	assert_gt("c", "b")
+	with AssertRaises(AssertionError):
+		assert_gt("b", "b")
+	with AssertRaises(AssertionError):
+		assert_gt("a", "b")
+	
+	assert_ge("c", "b")
+	assert_ge("b", "b")
+	with AssertRaises(AssertionError):
+		assert_ge("a", "b")
+	
+	with AssertRaises(AssertionError):
+		assert_lt("c", "b")
+	with AssertRaises(AssertionError):
+		assert_lt("b", "b")
+	assert_lt("a", "b")
+	
+	with AssertRaises(AssertionError):
+		assert_le("c", "b")
+	assert_le("b", "b")
+	assert_lt("a", "b")
 
 
 def test_assert_ne():
-    assert_ne(1, 2)
-    assert_ne("abc", "abcd")
-    assert_ne(None, 1)
-    assert_ne(1.0004, 1.0005, tolerance=0.00001)
-    assert_ne(1, 1.01, tolerance=0.001)
+	assert_ne(1, 2)
+	assert_ne("abc", "abcd")
+	assert_ne(None, 1)
+	assert_ne(1.0004, 1.0005, tolerance=0.00001)
+	assert_ne(1, 1.01, tolerance=0.001)
 
 
 def test_assert_ne_with_failures():
-    with AssertRaises(AssertionError):
-        assert_ne(1, 1)
-    with AssertRaises(AssertionError):
-        assert_ne("abc", "abc")
-    with AssertRaises(AssertionError):
-        assert_ne(None, None)
-    with AssertRaises(AssertionError):
-        assert_ne(1.0004, 1.0005, tolerance=0.001)
-    with AssertRaises(AssertionError):
-        assert_ne(1, 1.0, tolerance=0.001)
-
-    # type errors
-    with AssertRaises(AssertionError):
-        assert_ne("s", 1, tolerance=0.1)
-    with AssertRaises(AssertionError):
-        assert_ne(None, 1, tolerance=0.1)
-    with AssertRaises(AssertionError):
-        assert_ne(1, 1, tolerance="s")
+	with AssertRaises(AssertionError):
+		assert_ne(1, 1)
+	with AssertRaises(AssertionError):
+		assert_ne("abc", "abc")
+	with AssertRaises(AssertionError):
+		assert_ne(None, None)
+	with AssertRaises(AssertionError):
+		assert_ne(1.0004, 1.0005, tolerance=0.001)
+	with AssertRaises(AssertionError):
+		assert_ne(1, 1.0, tolerance=0.001)
+	
+	# type errors
+	with AssertRaises(AssertionError):
+		assert_ne("s", 1, tolerance=0.1)
+	with AssertRaises(AssertionError):
+		assert_ne(None, 1, tolerance=0.1)
+	with AssertRaises(AssertionError):
+		assert_ne(1, 1, tolerance="s")
 
 
 def test_assert_is():
-    # Assign to val to make the assertion look more prototypical.
-    val = None
-    assert_is(None, val)
-    assert_is(int, type(1))
-
-    with AssertRaises(AssertionError):
-        assert_is(None, 1)
-    with AssertRaises(AssertionError):
-        assert_is(int, type("s"))
+	# Assign to val to make the assertion look more prototypical.
+	val = None
+	assert_is(None, val)
+	assert_is(int, type(1))
+	
+	with AssertRaises(AssertionError):
+		assert_is(None, 1)
+	with AssertRaises(AssertionError):
+		assert_is(int, type("s"))
 
 
 def test_assert_is_not():
-    assert_is_not(None, 1)
-    assert_is_not(int, type("s"))
-
-    # Assign to val to make the assertion look more prototypical.
-    val = None
-    with AssertRaises(AssertionError):
-        assert_is_not(None, val)
-    with AssertRaises(AssertionError):
-        assert_is_not(int, type(1))
+	assert_is_not(None, 1)
+	assert_is_not(int, type("s"))
+	
+	# Assign to val to make the assertion look more prototypical.
+	val = None
+	with AssertRaises(AssertionError):
+		assert_is_not(None, val)
+	with AssertRaises(AssertionError):
+		assert_is_not(int, type(1))
 
 
 def test_assert_not_in():
-    # test truncation of very long strings
-    seq = "a" * 1000 + "bbb" + "a" * 1000
-    with AssertRaises(AssertionError) as ar:
-        assert_not_in("bbb", seq)
-    e = ar.expected_exception_found
-    assert_eq(
-        "'bbb' is in '(truncated) ...%sbbb%s... (truncated)'" % ("a" * 50, "a" * 50),
-        str(e),
-    )
-
-    # same as above when the match is at index 0
-    seq = "a" * 1000
-    with AssertRaises(AssertionError) as ar:
-        assert_not_in("aaa", seq)
-    e = ar.expected_exception_found
-    assert_eq("'aaa' is in 'aaa%s... (truncated)'" % ("a" * 50), str(e))
+	# test truncation of very long strings
+	seq = "a" * 1000 + "bbb" + "a" * 1000
+	with AssertRaises(AssertionError) as ar:
+		assert_not_in("bbb", seq)
+	e = ar.expected_exception_found
+	assert_eq(
+		"'bbb' is in '(truncated) ...%sbbb%s... (truncated)'" % ("a" * 50, "a" * 50),
+		str(e),
+	)
+	
+	# same as above when the match is at index 0
+	seq = "a" * 1000
+	with AssertRaises(AssertionError) as ar:
+		assert_not_in("aaa", seq)
+	e = ar.expected_exception_found
+	assert_eq("'aaa' is in 'aaa%s... (truncated)'" % ("a" * 50), str(e))
 
 
 def test_assert_use_ascii_representation():
-    non_ascii_string = "Hello سلام"
-    with AssertRaises(AssertionError) as ar:
-        assert_eq("aaa", non_ascii_string)
-    e = ar.expected_exception_found
-    assert_eq("'aaa' != 'Hello \\u0633\\u0644\\u0627\\u0645'", str(e))
+	non_ascii_string = "Hello سلام"
+	with AssertRaises(AssertionError) as ar:
+		assert_eq("aaa", non_ascii_string)
+	e = ar.expected_exception_found
+	assert_eq("'aaa' != 'Hello \\u0633\\u0644\\u0627\\u0645'", str(e))
 
 
 class SpecificException(Exception):
-    pass
+	pass
 
 
 class SpecificException2(Exception):
-    pass
+	pass
 
 
 class TestAssertRaises:
-    def test_handles_specific_exceptions(self):
-        with AssertRaises(SpecificException, SpecificException2):
-            raise SpecificException("foo")
-
-    def test_handles_any_exceptions(self):
-        with AssertRaises(Exception):
-            raise Exception("foo")
-
-    def test_fails_if_raise_wrong_exception(self):
-        with AssertRaises(AssertionError):
-            with AssertRaises(SpecificException):
-                raise Exception("foo")
-
-    def test_fails_if_exception_not_raised(self):
-        try:
-            with AssertRaises(ValueError):
-                pass
-        except AssertionError:
-            pass
-        else:
-            assert False, "expected an exception to be raised"
-
-    def test_handles_multiple_exception_types(self):
-        with AssertRaises(IndexError, AssertionError):
-            assert False
-
-        with AssertRaises(AssertionError, IndexError):
-            print([][0])
-
-        class Assert2(AssertionError):
-            pass
-
-        class Index2(IndexError):
-            pass
-
-        with AssertRaises(AssertionError, IndexError):
-            raise Assert2("foo")
-
-        with AssertRaises(AssertionError, IndexError):
-            raise Index2("foo")
-
-    def test_with_extra(self):
-        with AssertRaises(AssertionError) as ar:
-            with AssertRaises(AssertionError, extra="extra message"):
-                pass
-        e = ar.expected_exception_found
-        assert_in("extra message", str(e))
-
-    def test_no_extra_kwargs(self):
-        with AssertRaises(AssertionError):
-            with AssertRaises(NotImplementedError, not_valid_kwarg=None):
-                pass
+	def test_handles_specific_exceptions(self):
+		with AssertRaises(SpecificException, SpecificException2):
+			raise SpecificException("foo")
+	
+	def test_handles_any_exceptions(self):
+		with AssertRaises(Exception):
+			raise Exception("foo")
+	
+	def test_fails_if_raise_wrong_exception(self):
+		with AssertRaises(AssertionError):
+			with AssertRaises(SpecificException):
+				raise Exception("foo")
+	
+	def test_fails_if_exception_not_raised(self):
+		try:
+			with AssertRaises(ValueError):
+				pass
+		except AssertionError:
+			pass
+		else:
+			assert False, "expected an exception to be raised"
+	
+	def test_handles_multiple_exception_types(self):
+		with AssertRaises(IndexError, AssertionError):
+			assert False
+		
+		with AssertRaises(AssertionError, IndexError):
+			print([][0])
+		
+		class Assert2(AssertionError):
+			pass
+		
+		class Index2(IndexError):
+			pass
+		
+		with AssertRaises(AssertionError, IndexError):
+			raise Assert2("foo")
+		
+		with AssertRaises(AssertionError, IndexError):
+			raise Index2("foo")
+	
+	def test_with_extra(self):
+		with AssertRaises(AssertionError) as ar:
+			with AssertRaises(AssertionError, extra="extra message"):
+				pass
+		e = ar.expected_exception_found
+		assert_in("extra message", str(e))
+	
+	def test_no_extra_kwargs(self):
+		with AssertRaises(AssertionError):
+			with AssertRaises(NotImplementedError, not_valid_kwarg=None):
+				pass
 
 
 def test_complex_assertions():
-    with AssertRaises(AssertionError):
-        with AssertRaises(AssertionError):
-            pass
-
-    with AssertRaises(RuntimeError):
-        raise RuntimeError()
-
-    assert_unordered_list_eq([1, 2, 2], [2, 1, 2])
-    with AssertRaises(AssertionError):
-        try:
-            assert_unordered_list_eq([1, 2, 2], [2, 1])
-        except AssertionError as e:
-            print(repr(e))
-            raise
+	with AssertRaises(AssertionError):
+		with AssertRaises(AssertionError):
+			pass
+	
+	with AssertRaises(RuntimeError):
+		raise RuntimeError()
+	
+	assert_unordered_list_eq([1, 2, 2], [2, 1, 2])
+	with AssertRaises(AssertionError):
+		try:
+			assert_unordered_list_eq([1, 2, 2], [2, 1])
+		except AssertionError as e:
+			print(repr(e))
+			raise
 
 
 def test_string_assertions():
-    assert_is_substring("a", "bca")
-    with AssertRaises(AssertionError):
-        assert_is_substring("a", "bc")
-
-    assert_is_not_substring("a", "bc")
-    with AssertRaises(AssertionError):
-        assert_is_not_substring("a", "bca")
-
-    assert_startswith("a", "abc bcd")
-    with AssertRaises(AssertionError):
-        assert_startswith("b", "abc bcd")
-
-    assert_endswith("d", "abc bcd")
-    with AssertRaises(AssertionError):
-        assert_endswith("c", "abc bcd")
+	assert_is_substring("a", "bca")
+	with AssertRaises(AssertionError):
+		assert_is_substring("a", "bc")
+	
+	assert_is_not_substring("a", "bc")
+	with AssertRaises(AssertionError):
+		assert_is_not_substring("a", "bca")
+	
+	assert_startswith("a", "abc bcd")
+	with AssertRaises(AssertionError):
+		assert_startswith("b", "abc bcd")
+	
+	assert_endswith("d", "abc bcd")
+	with AssertRaises(AssertionError):
+		assert_endswith("c", "abc bcd")
 
 
 class ExceptionWithValue(Exception):
-    def __init__(self, value):
-        self.value = value
+	def __init__(self, value):
+		self.value = value
 
 
 def test_assert_error_saves_exception():
-    assertion = AssertRaises(ExceptionWithValue)
-    with assertion:
-        raise ExceptionWithValue(5)
-    assert_eq(5, assertion.expected_exception_found.value)
+	assertion = AssertRaises(ExceptionWithValue)
+	with assertion:
+		raise ExceptionWithValue(5)
+	assert_eq(5, assertion.expected_exception_found.value)
 
 
 def test_message():
-    try:
-        assert_is(1, None, message="custom message")
-    except AssertionError as e:
-        assert_in("custom message", str(e))
-    else:
-        assert False, "should have thrown assertion error"
+	try:
+		assert_is(1, None, message="custom message")
+	except AssertionError as e:
+		assert_in("custom message", str(e))
+	else:
+		assert False, "should have thrown assertion error"
 
 
 def test_extra():
-    try:
-        assert_eq("thing1", "thing2", extra="something extra")
-    except AssertionError as e:
-        assert_in("thing1", str(e))
-        assert_in("thing2", str(e))
-        assert_in("something extra", str(e))
-    else:
-        assert False, "should have thrown assertion error"
+	try:
+		assert_eq("thing1", "thing2", extra="something extra")
+	except AssertionError as e:
+		assert_in("thing1", str(e))
+		assert_in("thing2", str(e))
+		assert_in("something extra", str(e))
+	else:
+		assert False, "should have thrown assertion error"
 
 
 def test_assert_dict_eq():
-    assert_dict_eq({"a": 1}, {"a": 1})
-
-    with AssertRaises(AssertionError):
-        assert_dict_eq({"a": 1}, {"b": 1})
-    with AssertRaises(AssertionError):
-        assert_dict_eq({"a": "abc"}, {"a": "xyz"})
-
-    try:
-        assert_dict_eq({"a": {"b": {"c": 1}}}, {"a": {"b": {"d": 1}}})
-    except AssertionError as e:
-        assert_in("'a'->'b'", str(e))
-    else:
-        assert False, "should have thrown assertion error"
-
-    dd = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
-    dd["a"]["b"]["c"] = 1
-    assert_dict_eq({"a": {"b": {"c": 1}}}, dd)
-    assert_dict_eq(dd, {"a": {"b": {"c": 1}}})
+	assert_dict_eq({"a": 1}, {"a": 1})
+	
+	with AssertRaises(AssertionError):
+		assert_dict_eq({"a": 1}, {"b": 1})
+	with AssertRaises(AssertionError):
+		assert_dict_eq({"a": "abc"}, {"a": "xyz"})
+	
+	try:
+		assert_dict_eq({"a": {"b": {"c": 1}}}, {"a": {"b": {"d": 1}}})
+	except AssertionError as e:
+		assert_in("'a'->'b'", str(e))
+	else:
+		assert False, "should have thrown assertion error"
+	
+	dd = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+	dd["a"]["b"]["c"] = 1
+	assert_dict_eq({"a": {"b": {"c": 1}}}, dd)
+	assert_dict_eq(dd, {"a": {"b": {"c": 1}}})
 
 
 def test_assert_in_with_tolerance():
-    assert_in_with_tolerance(1, [1, 2, 3], 0)
-    with AssertRaises(AssertionError):
-        assert_in_with_tolerance(1, [2, 2, 2], 0)
-    assert_in_with_tolerance(1, [2, 2, 2], 1)
+	assert_in_with_tolerance(1, [1, 2, 3], 0)
+	with AssertRaises(AssertionError):
+		assert_in_with_tolerance(1, [2, 2, 2], 0)
+	assert_in_with_tolerance(1, [2, 2, 2], 1)
+
+
+def test_assert_type_pass(self):
+	# Test cases where the assertion should pass
+	self.assertIsNone(assert_type(42, int))
+	self.assertIsNone(assert_type("Hello", str))
+	self.assertIsNone(assert_type(42.0, float))
+
+
+def test_assert_type_fail(self):
+	# Test cases where the assertion should fail
+	with AssertRaises(AssertionError):
+		assert_type(42, str)
+	
+	with AssertRaises(AssertionError):
+		assert_type("Hello", int)


### PR DESCRIPTION
adds a new assertion method, `assert_type`, to our codebase. The `assert_type` method allows us to assert that an object is of a specific type without considering inheritance, similar to `assert_is_instance` but with stricter type checking.
```py
assert_type(42, int)       # Passes
assert_type("Hello", str)  # Passes
assert_type(42.0, float)   # Passes

assert_type(42, str)       # Fails (Raises AssertionError)

```