### PR TITLE
remove nose usage from testing.disabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,6 @@ exclude = '''
 python_version = "3.9"
 warn_unused_configs = true
 
-[[tool.mypy.overrides]]
-module = "nose.plugins.skip"
-ignore_missing_imports = true
-
 [build-system]
 requires = ["setuptools>=64.0", "cython>=3"]
 build-backend = "setuptools.build_meta"

--- a/qcore/testing.py
+++ b/qcore/testing.py
@@ -43,9 +43,9 @@ __all__ = ["Anything", "GreaterEq"]
 # make the output more concise.
 # __unittest = 1
 
-
 import functools
 import inspect
+from unittest.case import SkipTest
 
 TEST_PREFIX = "test"
 
@@ -100,12 +100,7 @@ def disabled(func_or_class):
     def decorate_func(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            try:
-                from nose.plugins.skip import SkipTest
-            except ImportError:
-                return None  # do nothing, the test will show up as passed
-            else:
-                raise SkipTest
+            raise SkipTest
 
         return wrapper
 

--- a/qcore/tests/test_testing.py
+++ b/qcore/tests/test_testing.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.case import SkipTest
+
 from qcore.asserts import assert_eq, assert_is, AssertRaises
 from qcore.testing import (
     Anything,
@@ -48,13 +50,8 @@ def test_GreaterEq():
 
 
 def _check_disabled(fn):
-    try:
-        from nose.plugins.skip import SkipTest
-    except ImportError:
-        assert_is(None, fn())
-    else:
-        with AssertRaises(SkipTest):
-            fn()
+    with AssertRaises(SkipTest):
+        fn()
 
 
 def test_disabled():


### PR DESCRIPTION
nose does not work for recent Python versions anymore. unittest.SkipTest is available for >=2.7 which is enough for supported versions.