### PR TITLE
inspect: support get_original_fn for class method

### DIFF
--- a/qcore/inspection.py
+++ b/qcore/inspection.py
@@ -39,6 +39,12 @@ def get_original_fn(fn):
         except AttributeError:
             pass
         return original_fn
+    # Handle DecoratorBinder objects (e.g., AsyncDecoratorBinder)
+    # When a method decorated with DecoratorBase is accessed via Class.method or instance.method,
+    # Python's descriptor protocol automatically calls DecoratorBase.__get__(), which returns
+    # DecoratorBinder object. Get original function from DecoratorBinder -> .decorator -> .fn
+    if hasattr(fn, "decorator") and hasattr(fn.decorator, "fn"):
+        return get_original_fn(fn.decorator.fn)
     return fn
 
 


### PR DESCRIPTION
When a method decorated with DecoratorBase is accessed via Class.method or instance.method, Python's descriptor protocol automatically calls DecoratorBase.__get__(), which returns DecoratorBinder object.
One example is marking a class method by `asynq` (https://github.com/quora/asynq)